### PR TITLE
changed all faas examples to faas-cli

### DIFF
--- a/lab3.md
+++ b/lab3.md
@@ -14,7 +14,7 @@ There are two ways to create a new function:
 To find out which languages are available type in:
 
 ```
-$ faas new --list
+$ faas-cli new --list
 Languages available as templates:
 - csharp
 - go
@@ -40,7 +40,7 @@ We will create a hello-world function in Python, then move onto something that u
 * Scaffold the function
 
 ```
-$ faas new --lang python hello-openfaas
+$ faas-cli new --lang python hello-openfaas
 ```
 
 This will create three files for us:
@@ -95,9 +95,9 @@ Edit the message so it prints `hello world` instead i.e.
 This is the local developer-workflow for functions:
 
 ```
-$ faas build -f ./hello-openfaas.yml
-$ faas push -f ./hello-openfaas.yml
-$ faas deploy -f ./hello-openfaas.yml
+$ faas-cli build -f ./hello-openfaas.yml
+$ faas-cli push -f ./hello-openfaas.yml
+$ faas-cli deploy -f ./hello-openfaas.yml
 ```
 
 Followed by invoking the function via the UI, CLI, `curl` or another application.
@@ -123,7 +123,7 @@ Test out the function with `faas-cli invoke`, check `faas-cli invoke --help` for
 We'll create a function called `astronaut-finder` that pulls in a random name of someone in space aboard the International Space Station (ISS).
 
 ```
-$ faas new --lang python astronaut-finder
+$ faas-cli new --lang python astronaut-finder
 ```
 
 This will write three files for us:
@@ -184,7 +184,7 @@ def handle(req):
 Now build the function:
 
 ```
-$ faas build -f ./astronaut-finder.yml
+$ faas-cli build -f ./astronaut-finder.yml
 ```
 
 > Tip: If you rename astronaut-finder.yml to `stack.yml` then you can leave off the `-f` argument. `stack.yml` is the default file-name for the CLI.
@@ -192,16 +192,16 @@ $ faas build -f ./astronaut-finder.yml
 Deploy the function:
 
 ```
-$ faas deploy -f ./astronaut-finder.yml
+$ faas-cli deploy -f ./astronaut-finder.yml
 ```
 
 Invoke the function
 
 ```
-$ echo | faas invoke astronaut-finder
+$ echo | faas-cli invoke astronaut-finder
 Anton Shkaplerov is in space
 
-$ echo | faas invoke astronaut-finder
+$ echo | faas-cli invoke astronaut-finder
 Joe Acaba is in space
 ```
 
@@ -307,7 +307,7 @@ Here are several flags that help when working with a stack of functions:
 
 `faas-cli build -f ./example.yml --filter=second`
 
-Look at the options for `faas build --help` and `faas push --help` for more information.
+Look at the options for `faas-cli build --help` and `faas-cli push --help` for more information.
 
 > Pro-tip: `stack.yml` is the default name the faas-cli will look for if you don't want to pass a `-f` parameter.
 
@@ -318,11 +318,11 @@ You can also deploy function stack (yaml) files over HTTP(s) using `faas-cli -f 
 If you have your own language template or have found a community template such as the PHP template then you can add that with the following command:
 
 ```
-$ faas template pull https://github.com/itscaro/openfaas-template-php
+$ faas-cli template pull https://github.com/itscaro/openfaas-template-php
 
 ...
 
-faas new --list|grep php
+faas-cli new --list|grep php
 - php
 - php5
 ```
@@ -338,7 +338,7 @@ Custom binaries or containers can be used as functions, but most of the time usi
 To use a custom binary or Dockerfile create a new function using the `dockerfile` language:
 
 ```
-$ faas new --lang dockerfile sorter
+$ faas-cli new --lang dockerfile sorter
 ```
 
 You'll see a folder created named `sorter` and `sorter.yml`.
@@ -354,9 +354,9 @@ Edit `sorter.yml` and add your username as a prefix to the `image: sorter` field
 Now build, push and deploy the function:
 
 ```
-$ faas build -f sorter.yml \
-  && faas push -f sorter.yml
-  && faas deploy -f sorter.yml
+$ faas-cli build -f sorter.yml \
+  && faas-cli push -f sorter.yml
+  && faas-cli deploy -f sorter.yml
 ```
 
 Now invoke the function through the UI or via the CLI:
@@ -367,7 +367,7 @@ elephant
 zebra
 horse
 ardvark
-monkey'| faas invoke sorter -g 127.0.0.1:8080
+monkey'| faas-cli invoke sorter -g 127.0.0.1:8080
 
 ardvark
 elephant

--- a/lab4.md
+++ b/lab4.md
@@ -17,7 +17,7 @@ There are several places where a timeout can be configured for your function, in
 The API Gateway has a default of 20 seconds, so let's test out setting a shorter timeout on a function.
 
 ```
-$ faas new --lang python sleep-for
+$ faas-cli new --lang python sleep-for
 ```
 
 Edit `handler.py`:
@@ -60,16 +60,16 @@ functions:
 Use the CLI to build, push, deploy and invoke the function.
 
 ```
-$ echo | faas invoke sleep-for
+$ echo | faas-cli invoke sleep-for
 Server returned unexpected status code: 500 - Can't reach service: sleep-for
 ```
 
 You should see it terminate without printing the message.
 
-Now set `sleep_duration` to a lower number like `2` and run `faas deploy` again. You don't need to rebuild the function when editing the function's YAML file.
+Now set `sleep_duration` to a lower number like `2` and run `faas-cli deploy` again. You don't need to rebuild the function when editing the function's YAML file.
 
 ```
-$ echo | faas invoke sleep-for
+$ echo | faas-cli invoke sleep-for
 Starting to sleep for 2
 Finished the sleep
 ```
@@ -103,13 +103,13 @@ Let's try it out with a querystring and a function that lists off all environmen
 * Deploy a function that prints environmental variables using a built-in BusyBox command:
 
 ```
-$ faas deploy --name env --fprocess="env" --image="functions/alpine:latest" --network=func_functions
+$ faas-cli deploy --name env --fprocess="env" --image="functions/alpine:latest" --network=func_functions
 ```
 
 * Invoke the function with a querystring:
 
 ```
-$ echo "" | faas invoke env --query workshop=1
+$ echo "" | faas-cli invoke env --query workshop=1
 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 HOSTNAME=05e8db360c5a
 fprocess=env

--- a/lab5.md
+++ b/lab5.md
@@ -21,7 +21,7 @@ Asynchronous tasks run in a similar way with a few differences:
 Let's try a quick demo.
 
 ```
-$ faas new --lang dockerfile long-task
+$ faas-cli new --lang dockerfile long-task
 ```
 
 Edit `long-task/Dockerfile` and change the fprocess to `sleep 1`.

--- a/lab6.md
+++ b/lab6.md
@@ -24,7 +24,7 @@ Example:
 * Then push the output from NodeInfo through the Markdown converter
 
 ```
-$ echo -n "" | faas invoke nodeinfo | faas invoke func_markdown
+$ echo -n "" | faas-cli invoke nodeinfo | faas-cli invoke func_markdown
 <p>Hostname: 64767782518c</p>
 
 <p>Platform: linux
@@ -61,7 +61,7 @@ In Lab 3 we introduced the requests module and used it to call a remote API to g
 The Sentiment Analysis function will tell you the subjectivity and polarity (positivity rating) of any sentence. The result of the function is formatted in JSON as per the example below:
 
 ```
-echo -n "California is great, it's always sunny there." | faas invoke sentimentanalysis
+echo -n "California is great, it's always sunny there." | faas-cli invoke sentimentanalysis
 {"polarity": 0.8, "sentence_count": 1, "subjectivity": 0.75}
 ```
 

--- a/lab7.md
+++ b/lab7.md
@@ -40,9 +40,9 @@ $ faas-cli list --gateway http://fuh83fhfj.ngrok.io/
 ## Create an webhook receiver `issue-bot`
 
 ```
-$ faas new --lang python issue-bot --prefix="<your-docker-username-here>"
-$ faas build -f ./issue-bot.yml
-$ faas push -f ./issue-bot.yml
+$ faas-cli new --lang python issue-bot --prefix="<your-docker-username-here>"
+$ faas-cli build -f ./issue-bot.yml
+$ faas-cli push -f ./issue-bot.yml
 ```
 
 Now edit the function's YAML file `issue-bot.yml` and add an environmental variable of `write_debug: true`:
@@ -64,7 +64,7 @@ functions:
 * Deploy the function
 
 ```
-$ faas deploy -f ./issue-bot.yml
+$ faas-cli deploy -f ./issue-bot.yml
 ```
 
 ## Receive webhooks from GitHub
@@ -100,7 +100,7 @@ Now go to GitHub and create a new issue. Type "test" for the title and descripti
 Check how many times the function has been called - this number should be at least `1`.
 
 ```
-$ faas list
+$ faas-cli list
 Function    Invocations
 issue-bot   2
 ```
@@ -173,9 +173,9 @@ res = requests.post('http://' + gateway_hostname + ':8080/function/sentimentanal
 Use the CLI to build and deploy the function:
 
 ```
-$ faas build -f issue-bot.yml \
-  && faas push -f issue-bot.yml \
-  && faas deploy -f issue-bot.yml
+$ faas-cli build -f issue-bot.yml \
+  && faas-cli push -f issue-bot.yml \
+  && faas-cli deploy -f issue-bot.yml
 ```
 
 Now create a new issue in the `bot-tester` repository. GitHub will respond by sending a JSON payload to your function via the Ngrok tunnel we set up at the start.
@@ -329,9 +329,9 @@ def apply_label(polarity, issue_number, repo, positive_threshold):
 Use the CLI to build and deploy the function:
 
 ```
-$ faas build -f issue-bot.yml \
-  && faas push -f issue-bot.yml \
-  && faas deploy -f issue-bot.yml
+$ faas-cli build -f issue-bot.yml \
+  && faas-cli push -f issue-bot.yml \
+  && faas-cli deploy -f issue-bot.yml
 ```
 
 Now try it out by creating some new issues in the `bot-tester` repository. Check whether `positive` and `review` labels were properly applied and consult the GitHub Webhooks page if you are not sure that the messages are getting through or if you suspect an error is being thrown.


### PR DESCRIPTION
Signed-off-by: Burton Rheutan <rheutan7@gmail.com>

Standardized all uses of `faas` alias to use the default `faas-cli` command