### PR TITLE
Convert remaining print() statements to return

### DIFF
--- a/astronaut-finder/handler.py
+++ b/astronaut-finder/handler.py
@@ -8,4 +8,4 @@ def handle(req):
     index = random.randint(0, len(result["people"])-1)
     name = result["people"][index]["name"]
 
-    print("%s is in space" % name)
+    return "%s is in space" % (name)

--- a/hello-openfaas/handler.py
+++ b/hello-openfaas/handler.py
@@ -1,2 +1,2 @@
-def handle(st):
-    print(st)
+def handle(req):
+    return req

--- a/issue-bot/bot-handler/handler.py
+++ b/issue-bot/bot-handler/handler.py
@@ -5,8 +5,7 @@ def handle(req):
     event_header = os.getenv("Http_X_Github_Event")
 
     if not event_header == "issues":
-        print("Unable to handle X-GitHub-Event: " + event_header)
-        sys.exit(1)
+        sys.exit("Unable to handle X-GitHub-Event: " + event_header)
         return
 
     gateway_hostname = os.getenv("gateway_hostname", "gateway")
@@ -14,8 +13,7 @@ def handle(req):
     payload = json.loads(req)
 
     if not payload["action"] == "opened":
-        print("Action not supported: " + payload["action"])
-        sys.exit(1)
+        sys.exit("Action not supported: " + payload["action"])
         return
 
     # Call sentimentanalysis
@@ -23,8 +21,7 @@ def handle(req):
                         data= payload["issue"]["title"]+" "+payload["issue"]["body"])
 
     if res.status_code != 200:
-        print("Error with sentimentanalysis, expected: %d, got: %d\n" % (200, res.status_code))
-        sys.exit(1)
+        sys.exit("Error with sentimentanalysis, expected: %d, got: %d\n" % (200, res.status_code))
 
     # Read the positive_threshold from configuration
     positive_threshold = float(os.getenv("positive_threshold", "0.2"))

--- a/lab3.md
+++ b/lab3.md
@@ -205,7 +205,7 @@ def handle(req):
     index = random.randint(0, len(result["people"])-1)
     name = result["people"][index]["name"]
 
-    return name + " is in space"
+    return "%s is in space" % (name)
 ```
 
 > Note: in this example we do not make use of the parameter `req` but must keep it in the function's header.

--- a/lab4.md
+++ b/lab4.md
@@ -256,8 +256,7 @@ def handle(req):
     r = requests.get("http://" + gateway_hostname + ":8080/function/sentimentanalysis", data= test_sentence)
 
     if r.status_code != 200:
-        print("Error with sentimentanalysis, expected: %d, got: %d\n" % (200, r.status_code))
-        sys.exit(1)
+        sys.exit("Error with sentimentanalysis, expected: %d, got: %d\n" % (200, r.status_code))
 
     result = r.json()
     if result["polarity"] > 0.45:

--- a/lab5.md
+++ b/lab5.md
@@ -140,8 +140,7 @@ def handle(req):
     event_header = os.getenv("Http_X_Github_Event")
 
     if not event_header == "issues":
-        print("Unable to handle X-GitHub-Event: " + event_header)
-        sys.exit(1)
+        sys.exit("Unable to handle X-GitHub-Event: " + event_header)
         return
 
     gateway_hostname = os.getenv("gateway_hostname", "gateway")
@@ -155,8 +154,7 @@ def handle(req):
     res = requests.post('http://' + gateway_hostname + ':8080/function/sentimentanalysis', data=payload["issue"]["title"]+" "+payload["issue"]["body"])
 
     if res.status_code != 200:
-        print("Error with sentimentanalysis, expected: %d, got: %d\n" % (200, res.status_code))
-        sys.exit(1)
+        sys.exit("Error with sentimentanalysis, expected: %d, got: %d\n" % (200, res.status_code))
 
     return res.json()
 ```
@@ -278,8 +276,7 @@ def handle(req):
     event_header = os.getenv("Http_X_Github_Event")
 
     if not event_header == "issues":
-        print("Unable to handle X-GitHub-Event: " + event_header)
-        sys.exit(1)
+        sys.exit("Unable to handle X-GitHub-Event: " + event_header)
         return
 
     gateway_hostname = os.getenv("gateway_hostname", "gateway")
@@ -287,8 +284,7 @@ def handle(req):
     payload = json.loads(req)
 
     if not payload["action"] == "opened":
-        print("Action not supported: " + payload["action"])
-        sys.exit(1)
+        sys.exit("Action not supported: " + payload["action"])
         return
 
     # Call sentimentanalysis
@@ -296,8 +292,7 @@ def handle(req):
                         data= payload["issue"]["title"]+" "+payload["issue"]["body"])
 
     if res.status_code != 200:
-        print("Error with sentimentanalysis, expected: %d, got: %d\n" % (200, res.status_code))
-        sys.exit(1)
+        sys.exit("Error with sentimentanalysis, expected: %d, got: %d\n" % (200, res.status_code))
 
     # Read the positive_threshold from configuration
     positive_threshold = float(os.getenv("positive_threshold", "0.2"))

--- a/lab8.md
+++ b/lab8.md
@@ -33,9 +33,10 @@ def handle(req):
     """
 
     sleep_duration = int(os.getenv("sleep_duration", "10"))
-    print("Starting to sleep for %d" % sleep_duration)
+    preSleep = "Starting to sleep for %d" % sleep_duration
     time.sleep(sleep_duration)  # Sleep for a number of seconds
-    print("Finished the sleep")
+    postSleep = "Finished the sleep"
+    return preSleep + "\n" + postSleep
 ```
 
 Now edit the `sleep-for.yml` file and add these environmental variables:


### PR DESCRIPTION
Signed-off-by: rgee0 <richard@technologee.co.uk>

During the reordering of the labs a number of the code snippets were converted from showing `print(str)` to `return str` to better align with the current template pattern.  This change addresses the remaining items in that regard and also converts cases where errors were being printed before sys.exit(1) was being called.  When anything other than `None` or `0` passed in to sys.exit()  the value is passed out to stderr and a exit code of 1 is returned; this means that separate print and sys.exit statements are unnecessary.