### PR TITLE
Update secret path

### DIFF
--- a/issue-bot-secrets/bot-handler/handler.py
+++ b/issue-bot-secrets/bot-handler/handler.py
@@ -41,7 +41,7 @@ def handle(req):
 
 def apply_label(polarity, issue_number, repo, positive_threshold):
 
-    with open("/run/secrets/auth-token","r") as authToken:  
+    with open("/var/openfaas/secrets/auth-token","r") as authToken:
         g = Github(authToken.read())
     
     repo = g.get_repo(repo)

--- a/lab10.md
+++ b/lab10.md
@@ -33,8 +33,9 @@ Test that the secret was created:
 ```
 $ docker secret inspect auth-token
 ```
+> Note: If you are deploying your function on a remote gateway make sure you create your secret on the virtual machine you use for the gateway.
 
-When the secret is mounted by a function it will be presented as a file under `/run/secrets/auth-token`. This can be read by `handler.py` to obtain the GitHub *Personal Access Token*.
+When the secret is mounted by a function it will be presented as a file under `/var/openfaas/secrets/auth-token`. This can be read by `handler.py` to obtain the GitHub *Personal Access Token*.
 
 ### Update issue-bot.yml
 


### PR DESCRIPTION
With this change secret path is updated from `/run/secrets/auth-token` to `/var/openfaas/secrets/auth-token`.
It also adds note for creating auth-token when a remote gateway is used.

Resolves [#49](https://github.com/openfaas/workshop/issues/49)

Signed-off-by: Martin Dekov (VMware) <mdekov@vmware.com>