### PR TITLE
Update README with instructor-led prereqs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,15 @@ Docker:
 
 If you're taking an instructor-led workshops then a link will be shared to join the OpenFaaS Slack community. Use the designated channel for the workshop to discuss comments, questions and suggestions.
 
+**Before you arrive on-site for the instructor-led workshop, please make sure you have run the following commands:**
+
+```
+$ git clone https://github.com/openfaas/workshop
+$ git clone https://github.com/openfaas/faas
+$ cd faas \
+  && docker-compose pull
+```
+
 ## [Lab 1 - Prepare for OpenFaaS](./lab1.md)
 
 * Install pre-requisites


### PR DESCRIPTION
Due to limited bandwidth at workshop venues, it may make sense for workshop attendees to clone the repositories and pull down the basic images for OpenFaaS, to remove any delay in getting the services started at the beginning of the workshop.

Signed-off-by: Jonas Rosland <jrosland@vmware.com>