### PR TITLE
Reorder lab 1 so that OpenFaaS is installed before the CLI

### DIFF
--- a/lab1.md
+++ b/lab1.md
@@ -58,31 +58,6 @@ $ docker login
 
 > Note: Tip from community - if you get an error while trying to run this command on a Windows machine, then click on the Docker for Windows icon in the taskbar and log into Docker there instead "Sign in / Create Docker ID".
 
-### OpenFaaS CLI
-
-You can install the OpenFaaS CLI with `brew` on a Mac or with a utility script on Mac or Linux:
-
-Using a Terminal on Mac or Linux:
-
-```
-$ curl -sL cli.openfaas.com | sudo sh
-```
-
-On Windows download the the latest `faas-cli.exe` from the [releases page](https://github.com/openfaas/faas-cli/releases). You can place it in a local directory or in the `C:\Windows\` path so that it's available from a command prompt.
-
-> If you're an advanced Windows user, place the CLI in a directory of your choice and then add that folder to your PATH environmental variable.
-
-We will use the `faas-cli` to scaffold new functions, build, deploy and invoke functions. You can find out commands available for the cli with `faas-cli --help`.
-
-Test the `faas-cli`
-
-Open a Terminal or Git Bash window and type in:
-
-```
-$ faas-cli help
-$ faas-cli version
-```
-
 
 ### Deploy OpenFaaS
 
@@ -118,5 +93,31 @@ $ docker service ls
 ```
 
 If you run into any problems, please consult the [Deployment guide](https://github.com/openfaas/faas/blob/master/guide/deployment_swarm.md) for Docker Swarm.
+
+
+### OpenFaaS CLI
+
+You can install the OpenFaaS CLI with `brew` on a Mac or with a utility script on Mac or Linux:
+
+Using a Terminal on Mac or Linux:
+
+```
+$ curl -sL cli.openfaas.com | sudo sh
+```
+
+On Windows download the the latest `faas-cli.exe` from the [releases page](https://github.com/openfaas/faas-cli/releases). You can place it in a local directory or in the `C:\Windows\` path so that it's available from a command prompt.
+
+> If you're an advanced Windows user, place the CLI in a directory of your choice and then add that folder to your PATH environmental variable.
+
+We will use the `faas-cli` to scaffold new functions, build, deploy and invoke functions. You can find out commands available for the cli with `faas-cli --help`.
+
+Test the `faas-cli`
+
+Open a Terminal or Git Bash window and type in:
+
+```
+$ faas-cli help
+$ faas-cli version
+```
 
 Now move onto [Lab 2](./lab2.md)


### PR DESCRIPTION
Recent changes to the CLI means that the CLI tries to obtain information
from a gateway when the version command is invoked.  Lab 1 was tasking
the user to install the CLI before OpenFaaS which means a gateway wouldnt
be available for a new user.  This change swaps the order so that the CLI
is installed last.

Signed-off-by: Richard Gee <richard@technologee.co.uk>