### PR TITLE
Add instructions for Kubernetes

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ If you're taking an instructor-led workshops then a link will be shared to join 
 ## [Lab 1 - Prepare for OpenFaaS](./lab1.md)
 
 * Install pre-requisites
-* Set up a single-node cluster with Docker Swarm
+* Set up a single-node cluster with Docker Swarm or Kubernetes
 * Docker Hub account
 * OpenFaaS CLI
 * Deploy OpenFaaS

--- a/lab1.md
+++ b/lab1.md
@@ -2,7 +2,7 @@
 
 <img src="https://github.com/openfaas/media/raw/master/OpenFaaS_Magnet_3_1_png.png" width="500px"></img>
 
-OpenFaaS runs on top of several major platforms including Docker Swarm and Kubernetes. For this tutorial we will get started with Docker Swarm on your local computer.
+OpenFaaS runs on top of several major platforms including Docker Swarm and Kubernetes. For this tutorial you can choose one of both on your local computer.
 
 The basic primitive for any OpenFaaS function is a Docker image, which is built using the `faas-cli` tool-chain.
 
@@ -33,101 +33,8 @@ Linux - Ubuntu or Debian
 
 Note: As a last resort if you have an incompatible PC you can run the workshop on https://labs.play-with-docker.com/.
 
-### Setup a single-node cluster
+If you're taking part in a workshop event then the organiser will probably ask you to use Docker Swarm because it's much easier to set up in a short period of time. There are [deployment guides for both Swarm and Kubernetes in the documentation](https://github.com/openfaas/faas/tree/master/guide).
 
-#### Docker Swarm
+In order to set up OpenFaaS with Docker Swarm, go to [Lab 1a](./lab1a.md)
 
-OpenFaaS works both with Kubernetes and Docker Swarm. If you're taking part in a workshop event then the organiser will probably ask you to use Docker Swarm because it's much easier to set up in a short period of time. There are [deployment guides for both options in the documentation](https://github.com/openfaas/faas/tree/master/guide).
-
-On your laptop or VM setup a single-node Docker Swarm:
-
-```
-$ docker swarm init
-```
-
-> If you receive an error then pass the `--advertise-addr` parameter along with your laptop's IP address.
-
-#### Kubernetes
-
-You can follow the labs whilst using Kubernetes, but you may need to make some small changes along the way. The service address for the gateway changes from `http://gateway:8080` to `http://gateway.openfaas:8080`.
-
-If using a `NodePort` then the gateway address for the OpenFaaS CLI is normally http://IP_ADDRESS:31112/
-
-### Docker Hub
-
-Sign up for a Docker Hub account. The [Docker Hub](https://hub.docker.com) allows you to publish your Docker images on the Internet for use on multi-node clusters or to share with the wider community. We will be using the Docker Hub to publish our functions during the workshop.
-
-You can sign up here: [Docker Hub](https://hub.docker.com)
-
-> Note: The Docker Hub can also be setup to automate builds of Docker images.
-
-Open a Terminal or Git Bash window and log into the Docker Hub using the username you signed up for above.
-
-```
-$ docker login
-```
-
-> Note: Tip from community - if you get an error while trying to run this command on a Windows machine, then click on the Docker for Windows icon in the taskbar and log into Docker there instead "Sign in / Create Docker ID".
-
-### OpenFaaS CLI
-
-You can install the OpenFaaS CLI with `brew` on a Mac or with a utility script on Mac or Linux:
-
-Using a Terminal on Mac or Linux:
-
-```
-$ curl -sL cli.openfaas.com | sudo sh
-```
-
-On Windows download the the latest `faas-cli.exe` from the [releases page](https://github.com/openfaas/faas-cli/releases). You can place it in a local directory or in the `C:\Windows\` path so that it's available from a command prompt.
-
-> If you're an advanced Windows user, place the CLI in a directory of your choice and then add that folder to your PATH environmental variable.
-
-We will use the `faas-cli` to scaffold new functions, build, deploy and invoke functions. You can find out commands available for the cli with `faas-cli --help`.
-
-Test the `faas-cli`
-
-Open a Terminal or Git Bash window and type in:
-
-```
-$ faas-cli help
-$ faas-cli version
-```
-
-
-### Deploy OpenFaaS
-
-The instructions for deploying OpenFaaS change from time to time as we strive to make this easier. The following will get OpenFaaS deployed in around 60 seconds:
-
-* First clone the repo:
-
-```
-$ git clone https://github.com/openfaas/faas
-```
-
-* Now checkout the latest version with Git
-
-```
-$ cd faas && \
-  git checkout master
-```
-
-> Note: you can see the latest releases on the [project release page](https://github.com/openfaas/faas/releases).
-
-* Now deploy the stack with Docker Swarm:
-
-```
-$ ./deploy_stack.sh --no-auth
-```
-
-You should now have OpenFaaS deployed. If you are on a shared WiFi connection at an event then it may take several minutes to pull down all the Docker images and start them.
-
-Check the services show `1/1` on this screen:
-
-```
-$ docker service ls
-```
-
-If you run into any problems, please consult the [Deployment guide](https://github.com/openfaas/faas/blob/master/guide/deployment_swarm.md) for Docker Swarm.
-
-Now move onto [Lab 2](./lab2.md)
+If you're going to use Kubernetes, follow [Lab 1b](./lab1b.md)

--- a/lab10.md
+++ b/lab10.md
@@ -24,15 +24,32 @@ This is a more secure alternative to environmental variables. Environmental vari
 
 From a terminal run the following command:
 
+#### _Docker Swarm_
+
 ```
 $ echo -n <auth_token> | docker secret create auth-token -
 ```
 
+#### _Kubernetes_
+
+```
+kubectl create secret generic auth-token --from-literal=auth-token=<auth-token> --namespace openfaas-fn
+```
+
 Test that the secret was created:
+
+#### _Docker Swarm_
 
 ```
 $ docker secret inspect auth-token
 ```
+
+#### _Kubernetes_
+
+```
+kubectl get secret auth-token -n openfaas-fn -o json
+```
+
 > Note: If you are deploying your function on a remote gateway make sure you create your secret on the virtual machine you use for the gateway.
 
 When the secret is mounted by a function it will be presented as a file under `/var/openfaas/secrets/auth-token`. This can be read by `handler.py` to obtain the GitHub *Personal Access Token*.
@@ -59,6 +76,11 @@ functions:
       - auth-token
 
 ```
+
+> Note: If you're running on Kubernetes, suffix the `gateway_hostname` with `openfaas` namespace:
+> ```
+> gateway_hostname: "gateway.openfaas"
+> ```
 
 ### Update the `issue-bot` function
 

--- a/lab1a.md
+++ b/lab1a.md
@@ -1,0 +1,90 @@
+# Lab 1a - Set-up OpenFaaS with Docker Swarm
+
+<img src="https://www.ibm.com/blogs/bluemix/wp-content/uploads/2018/10/swarm1-300x300.png" width="300px"></img>
+
+### Setup a single-node cluster
+
+OpenFaaS works both with Kubernetes and Docker Swarm. If you're taking part in a workshop event then the organiser will probably ask you to use Docker Swarm because it's much easier to set up in a short period of time. There are [deployment guides for both options in the documentation](https://github.com/openfaas/faas/tree/master/guide).
+
+On your laptop or VM setup a single-node Docker Swarm:
+
+```
+$ docker swarm init
+```
+
+> If you receive an error then pass the `--advertise-addr` parameter along with your laptop's IP address.
+
+### Docker Hub
+
+Sign up for a Docker Hub account. The [Docker Hub](https://hub.docker.com) allows you to publish your Docker images on the Internet for use on multi-node clusters or to share with the wider community. We will be using the Docker Hub to publish our functions during the workshop.
+
+You can sign up here: [Docker Hub](https://hub.docker.com)
+
+> Note: The Docker Hub can also be setup to automate builds of Docker images.
+
+Open a Terminal or Git Bash window and log into the Docker Hub using the username you signed up for above.
+
+```
+$ docker login
+```
+
+> Note: Tip from community - if you get an error while trying to run this command on a Windows machine, then click on the Docker for Windows icon in the taskbar and log into Docker there instead "Sign in / Create Docker ID".
+
+### OpenFaaS CLI
+
+You can install the OpenFaaS CLI with `brew` on a Mac or with a utility script on Mac or Linux:
+
+Using a Terminal on Mac or Linux:
+
+```
+$ curl -sL cli.openfaas.com | sudo sh
+```
+
+On Windows download the the latest `faas-cli.exe` from the [releases page](https://github.com/openfaas/faas-cli/releases). You can place it in a local directory or in the `C:\Windows\` path so that it's available from a command prompt.
+
+> If you're an advanced Windows user, place the CLI in a directory of your choice and then add that folder to your PATH environmental variable.
+
+We will use the `faas-cli` to scaffold new functions, build, deploy and invoke functions. You can find out commands available for the cli with `faas-cli --help`.
+
+Test the `faas-cli`
+
+Open a Terminal or Git Bash window and type in:
+
+```
+$ faas-cli help
+$ faas-cli version
+```
+
+
+### Deploy OpenFaaS
+
+The instructions for deploying OpenFaaS change from time to time as we strive to make this easier. The following will get OpenFaaS deployed in around 60 seconds:
+
+* First clone the repo:
+
+```
+$ git clone https://github.com/openfaas/faas
+```
+
+* Now checkout the latest version with Git
+
+```
+$ cd faas && \
+  git checkout master
+```
+
+> Note: you can see the latest releases on the [project release page](https://github.com/openfaas/faas/releases).
+
+* Now deploy the stack with Docker Swarm:
+
+```
+$ ./deploy_stack.sh --no-auth
+```
+
+```
+$ docker service ls
+```
+
+If you run into any problems, please consult the [Deployment guide](https://github.com/openfaas/faas/blob/master/guide/deployment_swarm.md) for Docker Swarm.
+
+Now move onto [Lab 2](./lab2.md)

--- a/lab1b.md
+++ b/lab1b.md
@@ -1,0 +1,152 @@
+# Lab 1 - Set-up OpenFaaS with Kubernetes
+
+<img src="https://kubernetes.io/images/kubernetes-horizontal-color.png" width="500px"></img>
+
+### Setup a single-node cluster
+
+You can follow the labs whilst using Kubernetes, but you may need to make some small changes along the way. The service address for the gateway changes from `http://gateway:8080` to `http://gateway.openfaas:8080`.
+
+If using a `NodePort` then the gateway address for the OpenFaaS CLI is normally http://IP_ADDRESS:31112/
+
+You can choose different options to run Kubernetes on your machine.
+
+Before proceeding, [Install kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
+
+#### _With Minikube_
+
+* To install Minikube download the proper installer from [latest release](https://github.com/kubernetes/minikube/releases) depending on your platform.
+* [Install Helm client](https://docs.helm.sh/using_helm/#installing-the-helm-client)
+
+* Now run Minikube with
+```
+$ minikube start
+```
+
+> Note: If you're having any issues on starting minikube, try
+> ```
+> $ minikube stop && minikube delete
+> ```
+> and then run `minikube start` again.
+
+* Initialize Helm and install Tiller with
+```
+$ helm init
+```
+
+The minikube VM is exposed to the host system via a host-only IP address. Check this IP with `minikube ip`.
+This is the IP you will later use for the gateway URL.
+
+#### _Docker for Mac_
+
+* [Install Docker for Mac](https://docs.docker.com/v17.12/docker-for-mac/install/)
+> Note that Kubernetes is only available in Docker for Mac 17.12 CE and higher
+
+#### _Run on GKE (Google Kubernetes Engine)_
+
+* Install [Google Cloud SDK](https://cloud.google.com/sdk/docs)
+
+Mac:
+```
+$ brew cask install google-cloud-sdk
+```
+
+Ubuntu:
+```
+$ sudo apt-get update && sudo apt-get install google-cloud-sdk
+```
+
+For Windows follow the instructions from the [Documentation](https://cloud.google.com/sdk/docs/#windows)
+
+*  Create Kubernetes cluster using the Google Cloud Platform.
+
+In the GCP console, go to Kubernetes Engine -> Clusters and create new cluster.
+
+* Once you have it, configure `kubectl` command-line access by running the following command:
+(You can copy the command from the GCP console after clicking `Connect`):
+```
+$ gcloud container clusters get-credentials <cluster_name> --zone <cluster_zone> --project <project_name>
+```
+
+Now verify `kubectl` is configured to the GKE cluster by
+```
+$ kubectl get nodes
+NAME                                   STATUS    ROLES     AGE       VERSION
+gke-name-default-pool-eceef152-qjmt   Ready     <none>    1h        v1.10.7-gke.2
+```
+
+* Create Load Balancer
+
+From GCP console, go to Network services -> Load balancing and create new load balancer for TCP.
+Select Instance group to match your cluster's group. Set port to `31112` and IP to `Ephemeral`.
+
+Save your load balancer IP as you will need it to set the gateway URL.
+
+### Docker Hub
+
+Sign up for a Docker Hub account. The [Docker Hub](https://hub.docker.com) allows you to publish your Docker images on the Internet for use on multi-node clusters or to share with the wider community. We will be using the Docker Hub to publish our functions during the workshop.
+
+You can sign up here: [Docker Hub](https://hub.docker.com)
+
+> Note: The Docker Hub can also be setup to automate builds of Docker images.
+
+Open a Terminal or Git Bash window and log into the Docker Hub using the username you signed up for above.
+
+```
+$ docker login
+```
+
+> Note: Tip from community - if you get an error while trying to run this command on a Windows machine, then click on the Docker for Windows icon in the taskbar and log into Docker there instead "Sign in / Create Docker ID".
+
+### OpenFaaS CLI
+
+You can install the OpenFaaS CLI with `brew` on a Mac or with a utility script on Mac or Linux:
+
+Using a Terminal on Mac or Linux:
+
+```
+$ curl -sL cli.openfaas.com | sudo sh
+```
+
+On Windows download the the latest `faas-cli.exe` from the [releases page](https://github.com/openfaas/faas-cli/releases). You can place it in a local directory or in the `C:\Windows\` path so that it's available from a command prompt.
+
+> If you're an advanced Windows user, place the CLI in a directory of your choice and then add that folder to your PATH environmental variable.
+
+We will use the `faas-cli` to scaffold new functions, build, deploy and invoke functions. You can find out commands available for the cli with `faas-cli --help`.
+
+Test the `faas-cli`
+
+Open a Terminal or Git Bash window and type in:
+
+```
+$ faas-cli help
+$ faas-cli version
+```
+
+### Deploy OpenFaaS
+
+The instructions for deploying OpenFaaS change from time to time as we strive to make this easier. The following will get OpenFaaS deployed in around 60 seconds:
+
+To deploy on Kubernetes, you can run the commands from the [Documentation](https://docs.openfaas.com/deployment/kubernetes/#b-deploy-using-kubectlyaml-for-development-only)
+
+Now set the `OPENFAAS_URL` variable to link to the proper IP:
+```bash
+export OPENFAAS_URL=http://IP_ADDRESS:31112
+```
+
+You should now have OpenFaaS deployed. If you are on a shared WiFi connection at an event then it may take several minutes to pull down all the Docker images and start them.
+
+Check the services show `1/1` on this screen:
+
+```
+$ kubectl get pods -n openfaas
+NAME                            READY     STATUS    RESTARTS   AGE
+alertmanager-f5b4dfb8b-ztbb7    1/1       Running   0          1h
+gateway-d8477b4b6-m962x         2/2       Running   0          1h
+nats-86955fb749-8w65j           1/1       Running   0          1h
+prometheus-7d78d54b57-nncss     1/1       Running   0          1h
+queue-worker-8698f5bb78-qfv6n   1/1       Running   0          1h
+```
+
+If you run into any problems, please consult the [Deployment guide](https://github.com/openfaas/faas/blob/master/guide/deployment_swarm.md) for Docker Swarm.
+
+Now move onto [Lab 2](./lab2.md)

--- a/lab2.md
+++ b/lab2.md
@@ -74,7 +74,7 @@ You can now test out the CLI, but first a note on alternate gateways URLs:
 
 If your gateway is not deployed at http://127.0.0.1:8080 then you will need to specify the alternative location. There are several ways to accomplish this:
 
-1. Set the environment variable `OPENFAAS_URL` and the `faas-cli` will point to that endpoint in your current shell session. For example: `export OPENFAAS_URL=http://openfaas.endpoint.com:8080`
+1. Set the environment variable `OPENFAAS_URL` and the `faas-cli` will point to that endpoint in your current shell session. For example: `export OPENFAAS_URL=http://openfaas.endpoint.com:8080`. This is already set in [Lab 1](./lab1.md) if you are following the Kubernetes instructions.
 2. Specify the correct endpoint inline with the `-g` or `--gateway` flag: `faas deploy --gateway http://openfaas.endpoint.com:8080`
 3. In your deployment YAML file, change the value specified by the `gateway:` object under `provider:`.
 
@@ -134,6 +134,8 @@ OpenFaaS tracks metrics on your functions automatically using Prometheus. The me
 
 Deploy OpenFaaS Grafana with:
 
+#### _Docker Swarm_
+
 ```bash
 $ docker service create -d \
 --name=grafana \
@@ -142,9 +144,45 @@ $ docker service create -d \
 stefanprodan/faas-grafana:4.6.3
 ```
 
+#### _Kubernetes_
+
+Run Grafana in OpenFaaS Kubernetes namespace:
+```
+kubectl -n openfaas run \
+--image=stefanprodan/faas-grafana:4.6.3 \
+--port=3000 \
+grafana
+```
+
+Expose Grafana with a NodePort:
+```
+kubectl -n openfaas expose deployment grafana \
+--type=NodePort \
+--name=grafana
+```
+
+Find Grafana node port address:
+```
+$ GRAFANA_PORT=$(kubectl -n openfaas get svc grafana -o jsonpath="{.spec.ports[0].nodePort}")
+$ GRAFANA_URL=http://IP_ADDRESS:$GRAFANA_PORT/dashboard/db/openfaas
+```
+where `IP_ADDRESS` is your corresponding IP for Kubernetes.
+
+Or you may run this port-forwarding command in order to be able to access Grafana on `http://127.0.0.1:3000`:
+```
+$ kubectl port-forward deployment/grafana 3000:3000 -n openfaas
+```
+
 After the service has been created open Grafana in your browser, login with username `admin` password `admin` and navigate to the pre-made OpenFaaS dashboard at:
 
+
+#### _Docker Swarm_
+
 [http://127.0.0.1:3000/dashboard/db/openfaas](http://127.0.0.1:3000/dashboard/db/openfaas)
+
+#### _Kubernetes_
+
+Use `$GRAFANA_URL` instead
 
 
 <a href="https://camo.githubusercontent.com/24915ac87ecf8a31285f273846e7a5ffe82eeceb/68747470733a2f2f7062732e7477696d672e636f6d2f6d656469612f4339636145364358554141585f36342e6a70673a6c61726765"><img src="https://camo.githubusercontent.com/24915ac87ecf8a31285f273846e7a5ffe82eeceb/68747470733a2f2f7062732e7477696d672e636f6d2f6d656469612f4339636145364358554141585f36342e6a70673a6c61726765" width="600px" /></a>

--- a/lab3.md
+++ b/lab3.md
@@ -243,10 +243,18 @@ Joe Acaba is in space
 
 You can find out high-level information on every invocation of your function via the container's logs:
 
+#### _Docker Swarm_
+
 ```
 $ docker service logs -f astronaut-finder
 astronaut-finder.1.1e1ujtsijf6b@nuc    | 2018/02/21 14:53:25 Forking fprocess.
 astronaut-finder.1.1e1ujtsijf6b@nuc    | 2018/02/21 14:53:26 Wrote 18 Bytes - Duration: 0.063269 seconds
+```
+
+#### _Kubernetes_
+
+```
+$ kubectl logs deployment/astronaut-finder -n openfaas-fn
 ```
 
 ## Troubleshooting: verbose output with `write_debug`

--- a/lab4.md
+++ b/lab4.md
@@ -31,8 +31,16 @@ Let's try it out with a querystring and a function that lists off all environmen
 
 * Deploy a function that prints environmental variables using a built-in BusyBox command:
 
+#### _Docker Swarm_
+
 ```
 $ faas-cli deploy --name env --fprocess="env" --image="functions/alpine:latest" --network=func_functions
+```
+
+#### _Kubernetes_
+
+```
+$ faas-cli deploy --name env --fprocess="env" --image="functions/alpine:latest"
 ```
 
 * Invoke the function with a querystring:
@@ -154,7 +162,7 @@ This should be an error message.
 {"Hello": "OpenFaaS"}
 ```
 
-> Note: If you check the container logs with `docker service logs hello-openfaas` you should not see the stderr output.
+> Note: If you check the container logs with `docker service logs hello-openfaas` (or `kubectl logs deployment/hello-openfaas -n openfaas-fn`) you should not see the stderr output.
 
 In the example we need the function to return valid JSON that can be parsed. Unfortunately the log message makes the output invalid,
 so we need to redirect the messages from stderr to the container's logs.
@@ -253,9 +261,18 @@ So the result shows us that our test sentence was both very subjective (75%) and
 
 The following code can be used to call the *Sentiment Analysis* function or any other function:
 
+#### _Docker Swarm_
+
 ```python
     test_sentence = "California is great, it's always sunny there."
     r = requests.get("http://gateway:8080/function/sentimentanalysis", text= test_sentence)
+```
+
+#### _Kubernetes_
+
+Suffix the gateway host with `openfaas` namespace:
+```python
+    r = requests.get("http://gateway.openfaas:8080/function/sentimentanalysis", text= test_sentence)
 ```
 
 Or via an environmental variable:

--- a/lab5.md
+++ b/lab5.md
@@ -29,9 +29,26 @@ You will need to receive incoming webhooks from GitHub. In production you will h
 
 Open a new Terminal and type in:
 
+### _Docker Swarm_
+
 ```
 $ docker run -p 4040:4040 -d --name=ngrok --net=func_functions \
   alexellis2/ngrok-admin http gateway:8080
+```
+
+#### _Kubernetes_
+
+```
+$ kubectl -n openfaas run \
+--image=alexellis2/ngrok-admin \
+--port=4040 \
+ngrok -- http gateway:8080
+
+$ kubectl -n openfaas expose deployment ngrok \
+--type=NodePort \
+--name=ngrok
+
+$ kubectl port-forward deployment/ngrok 4040:4040 -n openfaas
 ```
 
 Use the built-in UI of `ngrok` at http://127.0.0.1:4040 to find your HTTP URL. You will be given a URL that you can access over the Internet, it will connect directly to your OpenFaaS API Gateway.
@@ -112,7 +129,7 @@ issue-bot   2
 
 Each time you create an issue the count will increase due to GitHub's API invoking the function.
 
-You can see the payload sent via GitHub by typing in `docker service logs -f issue-bot`.
+You can see the payload sent via GitHub by typing in `docker service logs -f issue-bot` (or `kubectl logs deployment/issue-bot -n openfaas-fn`).
 
 The GitHub Webhooks page will also show every message sent under "Recent Deliveries", you can replay a message here and see the response returned by your function.
 
@@ -235,6 +252,11 @@ functions:
     environment_file:
     - env.yml
 ```
+
+> Note: If you're running on Kubernetes, suffix the `gateway_hostname` with `openfaas` namespace:
+> ```
+> gateway_hostname: "gateway.openfaas"
+> ```
 
 > The `positive_threshold` environmental variable is used to fine-tune whether an Issue gets the `positive` or `review` label.
 

--- a/lab7.md
+++ b/lab7.md
@@ -74,8 +74,16 @@ Asynchronous function calls are well-suited to tasks where you can defer the exe
 
 The default stack for OpenFaaS uses NATS Streaming for queueing and deferred execution. You can view the logs with the following command:
 
+#### _Docker Swarm_
+
 ```
 docker service logs -f func_queue-worker
+```
+
+#### _Kubernetes_
+
+```
+kubectl logs deployment/queue-worker -n openfaas`
 ```
 
 ## Use an `X-Callback-Url` with requestbin

--- a/lab9.md
+++ b/lab9.md
@@ -28,7 +28,18 @@ You can control the maximum amount of replicas that can spawn for a function by 
 
 ### Check out Prometheus
 
-Open Prometheus in a web-browser: `http://127.0.0.1:9090/graph`
+Open Prometheus in a web-browser:
+
+#### _Docker Swarm_
+
+`http://127.0.0.1:9090/graph`
+
+#### _Kubernetes_
+
+You will need to run this port-forwarding command in order to be able to access Prometheus on `http://127.0.0.1:9090`:
+```
+$ kubectl port-forward deployment/prometheus 9090:9090 -n openfaas
+```
 
 Now add a graph with all successful invocation of the deployed functions. We can do this by executing `rate( gateway_function_invocation_total{code="200"} [20s])` as a query. Resulting in a page that looks like this:
 
@@ -53,6 +64,8 @@ Use this script to invoke the `figlet` function over and over until you see the 
  ```bash
 $ while [ true ]; do curl -X POST http://127.0.0.1:8080/function/figlet; done;
  ```
+
+> Note: If you're running on Kubernetes, use `$OPENFAAS_URL` instead of `http://127.0.0.1:8080`
 
 ### Monitor for alerts
 


### PR DESCRIPTION
It is time to update the workshop with Kubernetes as it is a key part of the project.
This adds alternave `kubectl` commands and important notes.

Signed-off-by: Ivana Yovcheva <iyovcheva@vmware.com>

Resolves #42 and #64 

Needs update for Kubernetes setup instructions 