### PR TITLE
Update with `faas-cli up`

### DIFF
--- a/lab10.md
+++ b/lab10.md
@@ -80,9 +80,7 @@ with open("/var/openfaas/secrets/auth-token","r") as authToken:
 Use the CLI to build and deploy the function:
 
 ```
-$ faas-cli build -f issue-bot.yml \
-  && faas-cli push -f issue-bot.yml \
-  && faas-cli deploy -f issue-bot.yml
+$ faas-cli up -f issue-bot.yml
 ```
 
 You can return to the [main page](./README.md).

--- a/lab3.md
+++ b/lab3.md
@@ -131,9 +131,7 @@ Any values returned to stdout will subsequently be returned to the calling progr
 This is the local developer-workflow for functions:
 
 ```
-$ faas-cli build -f ./hello-openfaas.yml
-$ faas-cli push -f ./hello-openfaas.yml
-$ faas-cli deploy -f ./hello-openfaas.yml
+$ faas-cli up -f hello-openfaas.yml
 ```
 
 Followed by invoking the function via the UI, CLI, `curl` or another application.
@@ -347,6 +345,7 @@ $ faas-cli build -f ./example.yml --parallel=2
 $ faas-cli build -f ./example.yml --filter=second
 ```
 Look at the options for `faas-cli build --help` and `faas-cli push --help` for more information.
+To run `faas-cli build && faas-cli push && faas-cli deploy` together, use `faas-cli up` instead.
 
 > Pro-tip: `stack.yml` is the default name the faas-cli will look for if you don't want to pass a `-f` parameter.
 
@@ -391,9 +390,7 @@ ENV fprocess="sort"
 Now build, push and deploy the function:
 
 ```
-$ faas-cli build -f sorter.yml \
-  && faas-cli push -f sorter.yml \
-  && faas-cli deploy -f sorter.yml
+$ faas-cli up -f sorter.yml
 ```
 
 Now invoke the function through the UI or via the CLI:

--- a/lab4.md
+++ b/lab4.md
@@ -111,9 +111,7 @@ def handle(req):
 Build and deploy
 
 ```sh
-$ faas-cli build -f hello-openfaas.yml \
-  && faas-cli push -f hello-openfaas.yml \
-  && faas-cli deploy -f hello-openfaas.yml
+$ faas-cli up -f hello-openfaas.yml
 ```
 
 Now invoke the function with

--- a/lab5.md
+++ b/lab5.md
@@ -48,8 +48,6 @@ $ faas-cli list --gateway http://fuh83fhfj.ngrok.io/
 
 ```
 $ faas-cli new --lang python3 issue-bot --prefix="<your-docker-username-here>"
-$ faas-cli build -f ./issue-bot.yml
-$ faas-cli push -f ./issue-bot.yml
 ```
 
 Now edit the function's YAML file `issue-bot.yml` and add an environmental variable of `write_debug: true`:
@@ -68,10 +66,10 @@ functions:
       write_debug: true
 ```
 
-* Deploy the function
+* Build, push and deploy the function with
 
 ```
-$ faas-cli deploy -f ./issue-bot.yml
+$ faas-cli up -f ./issue-bot.yml
 ```
 
 ## Receive webhooks from GitHub
@@ -183,9 +181,7 @@ res = requests.post('http://' + gateway_hostname + ':8080/function/sentimentanal
 Use the CLI to build and deploy the function:
 
 ```
-$ faas-cli build -f issue-bot.yml \
-  && faas-cli push -f issue-bot.yml \
-  && faas-cli deploy -f issue-bot.yml
+$ faas-cli up -f issue-bot.yml
 ```
 
 Now create a new issue in the `bot-tester` repository. GitHub will respond by sending a JSON payload to your function via the Ngrok tunnel we set up at the start.
@@ -340,9 +336,7 @@ def apply_label(polarity, issue_number, repo, positive_threshold):
 Use the CLI to build and deploy the function:
 
 ```
-$ faas-cli build -f issue-bot.yml \
-  && faas-cli push -f issue-bot.yml \
-  && faas-cli deploy -f issue-bot.yml
+$ faas-cli up -f issue-bot.yml
 ```
 
 Now try it out by creating some new issues in the `bot-tester` repository. Check whether `positive` and `review` labels were properly applied and consult the GitHub Webhooks page if you are not sure that the messages are getting through or if you suspect an error is being thrown.

--- a/lab6.md
+++ b/lab6.md
@@ -56,9 +56,7 @@ The `content_type` key inside `environment` will set the `Content-Type` of the r
 Now build, push and deploy the function:
 
 ```
-$ faas-cli build -f show-html.yml \
-  && faas-cli push -f show-html.yml \
-  && faas-cli deploy -f show-html.yml
+$ faas-cli up -f show-html.yml
 ```
 
 Open your browser and access http://127.0.0.1:8080/function/show-html. The HTML should be properly rendered.
@@ -120,9 +118,7 @@ def handle(req):
 Now build, push and deploy the function:
 
 ```
-$ faas-cli build -f show-html.yml \
-  && faas-cli push -f show-html.yml \
-  && faas-cli deploy -f show-html.yml
+$ faas-cli up -f show-html.yml
 ```
 
 Open your browser and access http://127.0.0.1:8080/function/show-html. You should see a "Here's a new page!" HTML page rendered in the browser.
@@ -196,9 +192,7 @@ def handle(req):
 Now build, push and deploy the function:
 
 ```
-$ faas-cli build -f show-html.yml \
-  && faas-cli push -f show-html.yml \
-  && faas-cli deploy -f show-html.yml
+$ faas-cli up -f show-html.yml
 ```
 
 Open your browser and first access:
@@ -295,9 +289,7 @@ There is no need to change the `handler.py` because it can dynamically serve HTM
 Now build, push and deploy the function:
 
 ```
-$ faas-cli build -f show-html.yml \
-  && faas-cli push -f show-html.yml \
-  && faas-cli deploy -f show-html.yml
+$ faas-cli up -f show-html.yml
 ```
 
 This section assumes you have already deployed the *figlet* function from [Lab 2](./lab2.md).  


### PR DESCRIPTION
This change replaces
```
faas-cli build && \
faas-cli push && \
faas-cli deploy
```
with the cmd optimized alternative `faas-cli up`.
Still left build, push and deploy on some places to show we have
these commands as well

Signed-off-by: Ivana Yovcheva <iyovcheva@vmware.com>

Closes #59 