### PR TITLE
Add hmac validation pointing to lab11

### DIFF
--- a/lab5.md
+++ b/lab5.md
@@ -345,4 +345,8 @@ Now try it out by creating some new issues in the `bot-tester` repository. Check
 
 > Note: If the labels don't appear immediately, first try refreshing the page
 
+## Validate payload with HMAC
+
+To further protect your function with HMAC head over to [lab11](url when merged)
+
 Now move on to [Lab 6](lab6.md).


### PR DESCRIPTION
Adding final field to lab5 just before moving on to lab6
to point how to validate your payload using HMAC
with lab11

Needs #67 to be merged

Signed-off-by: Martin Dekov (VMware) <mdekov@vmware.com>