### PR TITLE
Add note to ensure Linux containers are being used

### DIFF
--- a/lab1.md
+++ b/lab1.md
@@ -18,6 +18,9 @@ For Windows
 
 * Use Windows 10 Pro or Enterprise only
 * Install [Docker CE for Windows](https://store.docker.com/editions/community/docker-ce-desktop-windows)
+
+> Please ensure you use the **Linux** containers Docker daemon by using the Docker menu in the Windows task bar notification area.
+
 * Install [Git Bash](https://git-scm.com/downloads)
 
 > Note: please use Git Bash for all steps: do not attempt to use *WSL* or *Bash for Windows*.


### PR DESCRIPTION
A recent issue (openfaas/faas#898)  was raised because a user could not access the gateway on a Windows 10 machine.  The provided detail suggested that the OpenFaaS containers were all showing 0 replicas, which has previously been caused by users not selecting Linux containers in the Windows menu.

This change to Lab 1 adds a note alongside the installation step to ensure that Linux mode is selected.

Signed-off-by: Richard Gee <richard@technologee.co.uk>