### PR TITLE
Add initial Japanese version of the OpenFaaS workshop

### DIFF
--- a/translations/ja/README.md
+++ b/translations/ja/README.md
@@ -1,0 +1,126 @@
+# OpenFaaSワークショップ
+
+このワークショップではOpenFaaSの使い方（functionのビルドからデプロイまで）を自分のペースで学んでいくことができます。
+
+![](https://github.com/openfaas/media/raw/master/OpenFaaS_Magnet_3_1_png.png)
+
+> このワークショップではまずローカルの開発環境にDocker for MacあるいはWindowsを使ってOpenFaaSをデプロイします。その次にPythonで作ったServerless functionをビルド、デプロイして実際に実行します。ここで扱うトピックとしては、pipを使った依存パッケージの管理、シークレットでAPIトークンを扱う方法、Prometheusでfunctionを監視、非同期に複数のfunctionを実行してアプリケーションを作る方法です。最後にIFTTT.comのイベントストリームに繋ぎます。これによってボットや自動返信機能、ソーシャルメディアやIoT機器との連携が可能になります。
+
+## 必要なもの:
+
+ここに記載している内容は [Lab 1](./lab1.md) で詳しく説明しますが、インストラクターが指導するワークショップに参加される場合はあらかじめ準備しておいてください。
+
+* ワークショップで作成するfunctionはPythonで書きます。よって、プログラミングやスクリプト経験があることが推奨されます。
+*  [VSCode](https://code.visualstudio.com/download) のようなエディタをインストールしてください。
+* Windowsであれば [Git Bash](https://git-scm.com/downloads) をインストールしてください。
+* 推奨OS：MacOS、Windows 10 Pro/Enterprise、Ubuntu Linux
+
+Docker：
+
+* Docker CE for [Mac](https://store.docker.com/editions/community/docker-ce-desktop-mac)/[Windows](https://store.docker.com/editions/community/docker-ce-desktop-windows) **Edge edition**
+* Docker CE for Linux
+
+> 注: もし上記の環境が準備できない場合は代替手段としては https://labs.play-with-docker.com/ で動作確認することができます。
+
+## インストラクター指導型のワークショップ
+
+インストラクターが指導するワークショップではOpenFaaSのSlackへの招待リンクが共有されます。Slackの指定されたチャンネルをワークショップでのディスカッションや質問、提案などに活用してください。
+
+## [Lab 1 - まずはOpenFaaSの準備](./lab1.md)
+
+* 必要なものをインストール
+* Docker Swarmを使ってシングルノードのクラスタをセットアップ
+* Docker Hubのアカウントについて
+* OpenFaaS CLI
+* OpenFaaSをデプロイ
+
+## [Lab 2 - OpenFaaSを試してみよう](./lab2.md)
+
+* UIを使ってみよう
+* Function Storeからデプロイ
+* OpenFaaSのCLIについて
+* Prometheusのメトリクスについて
+
+## [Lab 3 - はじめてのfunction](./lab3.md)
+
+* 新規functionの生成またはscaffold（スキャフォールド）について
+* astronaut-finder function（宇宙飛行士検索 function）を作ろう
+  * 依存パッケージを `pip` で追加しよう
+  * トラブルシュート：コンテナのログを探そう
+* トラブルシュート： `write_debug` を使ってデバッグしてみよう
+* サードパーティ製のテンプレートを使ってみよう
+
+## [Lab 4 - functionについてさらに掘り下げてみよう](./lab4.md)
+
+* 環境変数で任意の値を注入
+  * deploy時のyamlで指定
+  * クエリ文字列やヘッダなどのHTTPコンテキストで動的に指定
+* ログの活用方法
+* ワークフローを作ってみよう
+  * クライアント側でfunctionを連鎖させよう
+  * function内で別のfunctionを呼び出してみよう
+
+## [Lab 5 - Gitbotを作ろう](./lab5.md)
+
+> `issue-bot` というGithubのIssueに自動返信するボットを作ります
+
+* GitHubのアカウントを取得
+* ngrokでトンネルを作る
+* webhookを受け取れる `issue-bot` を作る
+* Sentiment Analysis functionのデプロイ
+* GitHub APIを使ってラベルを適用する方法
+* functionの仕上げ
+
+## [Lab 6 - functionでHTMLを扱ってみよう](./lab6.md)
+
+* 簡単なHTMLをfunctionから返す
+* HTMLファイルを読み込んで返すfunction
+* 他のfunctionとの組み合わせ
+
+## [Lab 7 - 非同期 function](./lab7.md)
+
+* 非同期 vs 同期 function
+* queue-worker のログを見てみよう
+* requestbinやngrokで `X-Callback-Url` を活用してみよう
+
+## [Lab 8 - 応用編 - タイムアウト](./lab8.md)
+
+* `read_timeout` でタイムアウトを調整しよう
+* 動作時間の長いfunctionに適応しよう
+
+## [Lab 9 - 応用編 - functionのオートスケール](./lab9.md)
+
+> オートスケールを実際に発火させよう
+
+* レプリカの最小数、最大数について
+* Prometheusでの確認
+* Prometheusのクエリを確認
+* functionをcurlで繰り返し呼び出す
+* オートスケールを監視
+
+## [Lab 10 - 応用編 - secretの使い方](./lab10.md)
+* issue-botでsecretを使うようにしよう
+  * Swarmのsecretを作ろう
+  * functionからsecretにアクセスしよう
+
+[Lab 1](lab1.md) から順番に進めていくことができます。
+
+## OpenFaaSの削除方法
+
+OpenFaaSが必要なくなった場合に、削除する方法は [こちら](https://github.com/openfaas/faas/blob/master/guide/troubleshooting.md#stop-and-remove-openfaas) にまとめてあります。
+
+## おわりに
+
+インストラクターが指導するワークショップであればここからQ&Aの時間とし、他にもさらなる応用トピックについて話しましょう。
+
+* functionのオートスケール
+* セキュリティについて
+  * TLS / Basic認証
+* オブジェクトストレージ
+* テンプレートのカスタマイズ方法
+
+他にも [appendix](./appendix.md) の追加情報も合わせて参考にしてください。
+
+## 謝辞
+
+このワークショップの作成やテストに協力していただけた @iyovcheva, @BurtonR, @johnmccabe, @laurentgrangeau, @stefanprodan, @kenfdev, @templum, rgee0 に心より感謝します。

--- a/translations/ja/appendix.md
+++ b/translations/ja/appendix.md
@@ -1,0 +1,52 @@
+# Appendix
+
+## Prometheusでメトリクスを確認する（PromQL）
+
+functionが何回呼ばれたかというのを見たいときには2つの方法があることがワークショップでわかったと思います：
+
+* OpenFaaSのUIからfunctionを選択して確認
+* `faas-cli list` で確認
+
+3つ目の方法としてPrometheusのUIから確認する方法があります。OpenFaaSはPrometheusにメトリクスを公開しています。
+
+http://127.0.0.1:9090 にアクセスしましょう（ローカルではなくリモートのサーバーを使っている場合は適宜変更してください）
+
+「Expression」に以下を入力してください：
+
+```
+rate ( gateway_function_invocation_total [20s] ) 
+```
+
+それでは *Execute* をクリックして、タブは *Graph* を選択しましょう。このグラフにはどのfunctionがいつ、どのくらい呼ばれたか可視化しています。
+
+Prometheusは継続的にこれらの情報を記録しています。HTTPのレスポンスコードで絞り込むこともできるので、失敗したfunctionの呼び出しなどを見つけることができます。
+
+以下を実行してみてください:
+
+```
+$ echo test | faas-cli invoke non-existing-function
+```
+
+少し間を置いてからPrometheusのUIを再度みてみましょう。404のエラーが `non-existing-function` に対して記録されているのが確認できます。
+
+HTTPレスポンスが200のものだけを見たい場合は次のコマンドをExpressionを入力します：
+
+```
+rate ( gateway_function_invocation_total{code="200"} [20s] ) 
+```
+
+`figlet` function の結果だけを見たい場合は以下のようになります：
+
+```
+rate ( gateway_function_invocation_total{function_name="figlet"} [20s] ) 
+```
+
+## Directorパターン (functionの連鎖)
+
+*Directorパターン* は [こちらのドキュメント](https://github.com/openfaas/faas/blob/master/guide/chaining_functions.md#function-director-pattern) で述べられていますが、 director としてのfunctionを一つ用意して、その function は他の functionを呼ぶためだけに作られています。これは [Lab6](./lab6.md) で紹介した function の連鎖方法の2つの方法を組み合わせたハイブリッドなアプローチになります。
+
+![](../../diagram/director_function.png)
+
+上の図では *director function* として「RSS Feed to MP3」というfunctionがあり、サーバーサイドの別のfunctionを2つ呼んで、結果を返すというワークフローを実現しています。director functionを使うメリットとしては、このfunctionもまたバージョン管理できますし、ビルド、デプロイも他のfunction同様に行うことができる点です。
+
+RSSのURLはdirectorを介して「Get RSS feed」functionに渡り、その結果（パースされたRSSフィード）はまたdirectorを介して「Text-ToSpeech」functionに渡り、結果としてMP3ファイルがdirectorから返ってくる流れとなります。

--- a/translations/ja/lab1.md
+++ b/translations/ja/lab1.md
@@ -1,0 +1,131 @@
+# Lab 1 - まずはOpenFaaSの準備
+
+<img src="https://github.com/openfaas/media/raw/master/OpenFaaS_Magnet_3_1_png.png" width="500px"></img>
+
+OpenFaaSはDocker SwarmやKubernetesといった様々なプラットフォーム上で動きます。このワークショップではローカルの環境でDocker Swarmを使います。
+
+どんなOpenFaaSのfunctionであっても基礎となるのはDockerイメージです。これは `faas-cli` を活用することで容易にビルドすることができます。
+
+## 必要なもの
+
+### Docker
+
+Mac
+
+* [Docker CE for Mac Edge Edition](https://store.docker.com/editions/community/docker-ce-desktop-mac) をインストール
+
+Windows
+
+* Windows 10 ProまたはEnterprise
+
+* [Docker CE for Windows](https://store.docker.com/editions/community/docker-ce-desktop-windows) をインストール
+
+* [Git Bash](https://git-scm.com/downloads) をインストール
+
+  > 注：このワークショップではWSL(Windows Subsystem for Linux)やBash for Windowsではなく、Git Bashを使うことを強くおすすめします。
+
+Linux - UbuntuまたはDebian
+
+* Docker CE for Linux
+
+  > 注： [Docker Store](https://store.docker.com) からDocker CEをインストールできます。
+
+
+
+> 注：上のどの方法も用意できない場合は https://labs.play-with-docker.com/ でワークショップを進めていくことができます。
+
+### シングルノードのクラスタをセットアップ
+
+##### Docker Swarm
+
+OpenFaaSはKubernetesとDocker Swarmどちらでも動きますが、ワークショップのイベントなどではDocker Swarmを使うことが多いかと思います。というのも、Docker Swarmの方がセットアップや使用するのが簡単だからです。公式ドキュメントにはKubernetesとDocker Swarm両方のクラスタを構築する方法が [載っています](https://github.com/openfaas/faas/tree/master/guide) 。
+
+それではまずはローカルあるいはVM環境でシングルノードのDocker Swarmをセットアップします：
+
+```
+$ docker swarm init
+```
+
+> もしエラーが起きる場合は `--advertise-addr` と環境のIPを指定してください
+
+##### Kubernetes
+
+Kubernetes上で構築したOpenFaaSでもこのワークショップを進めていくことができます。ただし、読み替えが必要な箇所が少しあります。例えば、OpenFaaSのgatewayサービスのアドレスは `http://gateway:8080` ではなく、 `http://gateway.openfaas:8080` になります。
+
+また、gatewayに `NodePort` を使用している場合はOpenFaaSのCLIからアクセスする場合は http://IP_ADDRESS:31112/ としてください。
+
+### Docker Hub
+
+[Docker Hub](https://hub.docker.com)のアカウントが必要になりますので登録してください。Docker Hubを使うことでDockerイメージをインターネット上に公開してマルチノードクラスタで使ったり、世界中の様々なコミュニティ向けに容易に共有できるようになります。このワークショップではDocker Hub上にfunctionを公開します。
+
+Docker Hubのアカウント登録は [こちら](https://hub.docker.com) から行います。
+
+> 注：Docker Hubを使うことでDockerイメージのビルドを自動化することも可能です。
+
+ターミナルまたはGit Bashを開き下記コマンドを実行します。Docker Hubに登録した認証情報でログインします。
+
+```
+$ docker login
+```
+
+> 注：コミュニティからのアドバイス - Windowsで上記コマンドを実行してエラーが発生する場合は、タスクバーのDocker for Windowsアイコンをクリックして「Sign in / Create Docker ID」からログインしてください。
+
+### OpenFaaS CLI
+
+OpenFaaS CLIはMacであれば `brew` でインストールできますし、MacやLinuxであれば下記コマンドでインストールできます：
+
+```
+$ curl -sL cli.openfaas.com | sudo sh
+```
+
+Windowsを使用している場合は [こちらのリリースページ](https://github.com/openfaas/faas-cli/releases) から最新の `faas-cli.exe` をダウンロードしてください。ローカルのディレクトリに格納してもいいいですし、 `C:\Windows\` 配下に置いてコマンドプロンプトから使えるようにしておくこともできます。
+
+> Windowsを使い慣れている方であれば、CLIを格納したディレクトリをPATH環境変数に追加するのも一つの方法です。
+
+このワークショップでは `faas-cli` を使って新規functionの作成、ビルド、デプロイ、そして呼び出しも行います。CLIで使えるコマンドは `faas-cli --help` でも確認可能です。
+
+`faas-cli` を試してみましょう
+
+ターミナルまたはGit Bashを開いて以下のコマンドを実行します：
+
+```
+$ faas-cli help
+$ faas-cli version
+```
+
+### OpenFaaSをデプロイ
+
+以下のコマンドを使えば約60秒で簡単にOpenFaaSがデプロイできます。：
+
+* まずはリポジトリをクローンします:
+
+```
+$ git clone https://github.com/openfaas/faas
+```
+
+* 最新版をチェックアウトします
+
+```
+$ cd faas && \
+  git checkout master
+```
+
+> 注: 最新版のリリースに関しては [release page](https://github.com/openfaas/faas/releases) で確認できます。
+
+* Docker Swarmでスタックをデプロイします：
+
+```
+$ ./deploy_stack.sh --no-auth
+```
+
+もしイベントに参加しながら上記コマンドを実行した場合はDockerイメージのpullなどに数分かかる可能性があります。
+
+以下のコマンドを実行した場合に画面上に `1/1` が出ていることと、 `running` ステータスであることを確認してください：
+
+```
+$ docker service ls
+```
+
+もし何か問題が発生する場合は [Docker Swarmのデプロイ手順(英語)](https://github.com/openfaas/faas/blob/master/guide/deployment_swarm.md) を確認してみてください。
+
+それでは [Lab 2](./lab2.md) に進みましょう。

--- a/translations/ja/lab10.md
+++ b/translations/ja/lab10.md
@@ -1,0 +1,86 @@
+# Lab 10 - 応用編 - secretの使い方
+
+<img src="https://github.com/openfaas/media/raw/master/OpenFaaS_Magnet_3_1_png.png" width="500px"></img>
+
+このラボを始める前にlab5からコピーを作成しましょう。
+
+```
+$ cp -r lab5 lab10 \
+   && cd lab10
+```
+
+[Lab 7](./lab7) では `issue-bot` がGitHubの *Personal Access Token* を環境変数（ `auth_token` ）から取得する方法についてみました。違う方法として **secret** を使って機密性の高い情報を扱うやり方があります。
+
+Dockerのドキュメントでは：
+
+> .. a secret is a blob of data, such as a password, SSH private key, SSL certificate, or another piece of data that should not be transmitted over a network or stored unencrypted in a Dockerfile or in your application’s source code.
+
+と書かれているように、機密性の高いデータを平文で扱いたくない場合に環境変数の代替として **secret** を使うことができます。環境変数は簡単に使えるのですが、機密性の低いデータを使う場合だけに使用されるべきです。 `auth_token` の値はといえば、 **secret** で保護するべきデータになります。
+
+## secretの作成
+
+> secretの名前にアンダースコア（_）を使用することは非推奨です。Docker SwarmからKubernetesへの移行もスムーズに行えるように使用は控えましょう。
+
+ターミナルで次のコマンドを実行します（ `auth_token` には実際のトークンの値を入れてください）：
+
+```
+$ echo -n <auth_token> | docker secret create auth-token -
+```
+
+secretが作られたことを確認します：
+
+```
+$ docker secret inspect auth-token
+```
+
+> 注：functionを（ローカル環境ではなく）リモートのgatewayにデプロイする場合は、そのリモートの環境にsecretを作ってください。
+
+secretが作られてfunctionにマウントされると `/var/openfaas/secrets/auth-token` というファイルになります。これを `handler.py` で読み込んでGitHubの *Personal Access Token* を取得することができます。
+
+## issue-bot.ymlを更新
+
+`env.yml` を参照していた箇所をやめて、以下のように `auth-token` というsecretがfunctionで使える設定に変更します：
+
+```yml
+provider:
+  name: faas
+  gateway: http://127.0.0.1:8080
+
+functions:
+  issue-bot:
+    lang: python3
+    handler: ./issue-bot
+    image: <Docker Hubのユーザー名>/issue-bot
+    environment:
+      write_debug: true
+      gateway_hostname: "gateway"
+      positive_threshold: 0.25
+    secrets:
+      - auth-token
+
+```
+
+## `issue-bot` functionの更新
+
+functionのハンドラも `auth-token` というsecretを使うようにロジックを変更する必要があります。これは簡単で、次の1行を変更するだけです：
+
+```python
+g = Github(os.getenv("auth_token"))
+```
+を以下に置き換えます：
+```python
+with open("/var/openfaas/secrets/auth-token","r") as authToken:  
+    g = Github(authToken.read())
+```
+
+> 完全なソースコードは [issue-bot-secrets/bot-handler/handler.py](../../issue-bot-secrets/bot-handler/handler.py) で確認することができます。
+
+* build、push、deployしましょう
+
+```
+$ faas-cli build -f issue-bot.yml \
+  && faas-cli push -f issue-bot.yml \
+  && faas-cli deploy -f issue-bot.yml
+```
+
+それでは [目次](./README.md) に戻りましょう。

--- a/translations/ja/lab2.md
+++ b/translations/ja/lab2.md
@@ -1,0 +1,155 @@
+# Lab 2 - OpenFaaSを試してみよう
+
+<img src="https://github.com/openfaas/media/raw/master/OpenFaaS_Magnet_3_1_png.png" width="500px"></img>
+
+このラボを始める前に作業用のディレクトリを作成しましょう：
+
+```
+$ mkdir -p lab2 \
+   && cd lab2
+```
+
+## UIを使ってみよう
+
+デプロイが完了したところで http://127.0.0.1:8080 にアクセスすることでOpenFaaSのUIが表示されます。
+
+> 注：`localhost` ではなく `127.0.0.1` を使っている点に注意してください。Linuxの環境によっては `localhost` ではIPv4/IPv6の競合が原因で固まることがあるためです。
+
+下のコマンドでサンプルのfunctionをデプロイすることができます：
+
+```
+$ faas-cli deploy -f https://raw.githubusercontent.com/openfaas/faas/master/stack.yml
+```
+
+![](../../screenshot/markdown_portal.png)
+
+これらはUIから直接試すことができます。例えばMarkdown functionを試してみましょう。MarkdownがHTMLに変換されます。
+
+*Request*のフィールドに以下を入力しましょう：
+
+```
+## The **OpenFaaS** _workshop_
+```
+
+では、 *Invoke* ボタンを押して Response body を確認しましょう。下のようなレスポンスが表示されるはずです。
+
+```
+<h2>The <strong>OpenFaaS</strong> <em>workshop</em></h2>
+```
+
+他にも次のフィールドを見てみましょう：
+
+* Status - functionが実行可能な状態かどうか。この状態がReadyでない限りfunctionはUIから呼び出せません。
+* Replicas - Swarmのクラスタに存在しているfunctionのレプリカの数
+* Image - Docker HubあるいはDockerリポジトリに置いているDockerイメージの名前
+* Invocation count - これはfunctionが呼び出された回数を表示しており、5秒毎に更新しています
+
+何度か *Invoke* してみて *Invocation count* が増えていくのを確認してみてください。
+
+
+
+## Function Storeからデプロイ
+
+OpenFaaSのFunction storeからもfunctionをデプロイすることができます。storeはコミュニティによって集められたfunctionのコレクションです。（もちろん、無料です）
+
+* *Deploy New Function* をクリック
+* *From Store* が選択されていることを確認
+* *Figlet* というfunctionを選択（検索バーからも絞込ができます）して *Deploy* をクリック
+
+左のfunction一覧に Figlet functionが表示されます。Docker Hubからのダウンロードが終わるまでしばらく待ってから、何か半角文字列を入力してMarkdown functionのときみたいに *Invoke* をクリックしてみましょう。
+
+下のようなASCIIロゴが生成されるはずです（ `100%` と入力した場合）：
+
+```
+ _  ___   ___ _  __
+/ |/ _ \ / _ (_)/ /
+| | | | | | | |/ / 
+| | |_| | |_| / /_ 
+|_|\___/ \___/_/(_)
+```
+
+## OpenFaaSのCLIについて
+
+CLIについて見ていこうと思いますが、その前にgatewayのURLについて：
+
+もし http://127.0.0.1:8080 にOpenFaaSのgatewayをデプロイしていない場合はCLIにその場所を教える必要があります。以下のいずれかの方法で設定できます：
+
+1. `OPENFAAS_URL` 環境変数を設定することで、同一セッション内であれば `faas-cli` はその値を参照します。例えば：  `export OPENFAAS_URL=http://openfaas.endpoint.com:8080`
+2. `faas-cli` のオプションとして `-g` または `--gateway` を指定することができます： `faas deploy --gateway http://openfaas.endpoint.com:8080`
+3. デプロイに使うYAML内で`provider:` の下の `gateway:` の値で設定することもできます。
+
+### デプロイしたfunctionを一覧表示
+
+下のコマンドを入力することでfunctionの一覧とともにレプリカの数や呼び出し回数を表示できます。
+
+```
+$ faas-cli list
+```
+
+*markdown* functionであれば `markdown` 、さらには *figlet* functionも呼び出し回数とともに表示されるはずです。
+
+それでは `verbose` フラグを試してみましょう
+
+```
+$ faas-cli list --verbose
+```
+
+または
+
+```
+$ faas-cli list -v
+```
+
+このオプションでDockerイメージ名も表示されるようになります。
+
+### function呼び出し
+
+それでは `faas-cli list` で表示されたfunctionをどれか選択してみましょう（ここでは `markdown` にします：
+
+```
+$ faas-cli invoke markdown
+```
+
+ここで、何か文字列を入力するように促されます。何かを入力して Control+D を押します。
+
+他にも `echo` や `uname -a` を `invoke` のインプットとしてパイプすることができます。
+
+```sh
+$ echo Hi | faas-cli invoke markdown
+
+$ uname -a | faas-cli invoke markdown
+```
+
+さらにはこのLabのmarkdownもHTMLに変換することだってできます：
+
+```sh
+$ git clone https://github.com/openfaas/workshop \
+   && cd workshop
+
+$ cat lab2.md | faas-cli invoke markdown
+```
+
+## モニタリング用のダッシュボード
+
+OpenFaaSはPrometheusでメトリクスを測定しています。これらのメトリクスは [Grafana](https://grafana.com) などのオープンソースツールを使うことで可視化することができます。
+
+下のコマンドでGrafanaをデプロイしてみましょう：
+
+```bash
+$ docker service create -d \
+--name=grafana \
+--publish=3000:3000 \
+--network=func_functions \
+stefanprodan/faas-grafana:4.6.3
+```
+
+サービスの作成が完了したらGrafanaをブラウザで開いてみましょう。ユーザー名 `admin` 、パスワードも `admin` で下のダッシュボードにアクセスしてみましょう：
+
+http://127.0.0.1:3000/dashboard/db/openfaas
+
+
+<a href="https://camo.githubusercontent.com/24915ac87ecf8a31285f273846e7a5ffe82eeceb/68747470733a2f2f7062732e7477696d672e636f6d2f6d656469612f4339636145364358554141585f36342e6a70673a6c61726765"><img src="https://camo.githubusercontent.com/24915ac87ecf8a31285f273846e7a5ffe82eeceb/68747470733a2f2f7062732e7477696d672e636f6d2f6d656469612f4339636145364358554141585f36342e6a70673a6c61726765" width="600px" /></a>
+
+*Grafanaを使ってOpenFaaSのメトリクスを可視化した様子*
+
+それでは [Lab 3](./lab3.md) に進みましょう。

--- a/translations/ja/lab3.md
+++ b/translations/ja/lab3.md
@@ -1,0 +1,425 @@
+# Lab 3 - はじめてのfunction
+
+<img src="https://github.com/openfaas/media/raw/master/OpenFaaS_Magnet_3_1_png.png" width="500px"></img>
+
+このラボを始める前に作業用のディレクトリを作成しましょう：
+
+```
+$ mkdir -p lab3 \
+   && cd lab3
+```
+
+## 新規functionの作り方
+
+新規functionには２つの作り方があります：
+
+* ビルトインまたはコミュニティで作られたコードのテンプレートを基にscaffold（スキャフォールド）
+* 既にもっているバイナリをfunctionに変換（上級者用）
+
+
+### 新規functionの生成またはscaffold（スキャフォールド）について
+
+テンプレートから新規functionを作る前に [Github上のテンプレート](https://github.com/openfaas/templates) をダウンロードしておきましょう：
+
+```
+$ faas-cli template pull
+
+Fetch templates from repository: https://github.com/openfaas/templates.git
+ Attempting to expand templates from https://github.com/openfaas/templates.git
+ Fetched 11 template(s) : [csharp dockerfile go go-armhf node node-arm64 node-armhf python python-armhf python3 ruby]
+```
+
+次のコマンドでどの言語が使えるか確認することができます：
+
+```
+$ faas-cli new --list
+Languages available as templates:
+- csharp
+- dockerfile
+- go
+- go-armhf
+- node
+- node-arm64
+- node-armhf
+- python
+- python-armhf
+- python3
+- ruby
+
+Or alternatively create a folder containing a Dockerfile, then pick
+the "Dockerfile" lang type in your YAML file.
+```
+
+現時点ではPython, Python 3, Ruby, Go, Node, CSharp などのfunctionが作成可能です。
+
+* ワークショップのサンプルのfunctionについて
+
+このワークショップのfunctionの例はOpenFaaSのコミュニティによって全て十分に*Python 3*でテストされていますが、 *Python 2.7* でも互換性はあるはずです。
+
+もし、Python 3ではなくPython 2.7を使いたい場合は `faas-cli new --lang python3` を `faas-cli new --lang python` に変えてください。
+
+### PythonでHello world
+
+それではhello-world functionをPythonで作って、その後依存パッケージを使うようなfunctionも作ってみましょう。
+
+* functionの基礎をscaffold
+
+```
+$ faas-cli new --lang python3 hello-openfaas --prefix="<ここにDocker Hubのユーザー名を入力>"
+```
+
+`--prefix` パラメータを使うことで `hello-openfaas.yml` で記載される `image:` の部分にDocker Hubのアカウント名を指定することができます。例えば [OpenFaaS](https://hub.docker.com/r/functions) のアカウントは `functions` という名前を使っているため、 `image: functions/hello-openfaas` としたいです。よって、 `--prefix="functions"` と指定することになります。
+
+もし `--prefix` を指定しなかったとしても、あとからYAMLを直接編集することができます。
+
+上のコマンドで以下の3つのファイルとディレクトリが作成されます：
+
+```
+./hello-openfaas.yml
+./hello-openfaas
+./hello-openfaas/handler.py
+./hello-openfaas/requirements.txt
+```
+
+YAML(.yml)ファイルはCLIがfunctionのビルド、Dockerイメージのプッシュ、そしてデプロイをするための設定が記載されています。
+
+> 注：KubernetesやリモートのOpenFaaSへfunctionをデプロイするときは、あらかじめfunctionをビルド後にプッシュしておく必要があります。
+>
+> このとき、gatewayのデフォルトのURL `127.0.0.1:8080` は `export OPENFAAS_URL=127.0.0.1:31112` することで環境変数で上書きすることができます。
+
+YAMLの中身は以下のようになります：
+
+```yaml
+provider:
+  name: faas
+  gateway: http://127.0.0.1:8080
+
+functions:
+  hello-openfaas:
+    lang: python3
+    handler: ./hello-openfaas
+    image: <Docker Hubのユーザー名>/hello-openfaas
+```
+
+* functionの名前は `functions` 直下のキーで指定します（例： `hello-openfaas` ）
+* 開発言語は `lang` で指定します
+* ビルドに使われるディレクトリは `handler` という名前になります。ファイルではなくディレクトリでなければいけません
+* Dockerイメージの名前は `image` で指定します
+
+`gateway` のURLはYAMLあるいはCLI（ `-g`, `--gateway` あるいは `OPENFAAS_URL` 環境変数）から上書きすることができます。
+
+`handler.py` の中身は以下のとおり：
+
+```python
+def handle(req):
+    """handle a request to the function
+    Args:
+        req (str): request body
+    """
+
+    return req
+```
+
+このfunctionは流れてきた情報をそのまま返します。なので、 `echo` functionのようなものです。
+
+ここでメッセージを `Hello OpenFaaS` にしてみましょう。
+
+```
+    return "Hello OpenFaaS"
+```
+
+標準出力に渡された値はすべて呼び出し元のプログラムに返されます。戻り値以外にも `print()` を使って標準出力からレスポンスを返す方法もあります。
+
+以下がfunction開発時のデベロッパーのワークフローになります：
+
+```
+$ faas-cli build -f ./hello-openfaas.yml
+$ faas-cli push -f ./hello-openfaas.yml
+$ faas-cli deploy -f ./hello-openfaas.yml
+```
+
+このあとUI、CLI、 `curl` やアプリケーションからfunctionを呼び出すことになります。
+
+functionには必ず以下のようなURLが割り振られます：
+
+```
+http://127.0.0.1:8080/function/<functionの名前>
+http://127.0.0.1:8080/function/figlet
+http://127.0.0.1:8080/function/hello-openfaas
+```
+
+> Tips：YAMLファイルを `stack.yml` に変更するとCLI実行時に `-f` フラグが不要になります。
+
+functionは `GET` または `POST` でのみ呼び出すことができます。
+
+* functionを呼び出してみよう
+
+それでは `faas-cli invoke` を使ってfunctionを呼び出してみましょう。 `faas-cli invoke --help` で他のオプションも確認できます。
+
+
+
+### astronaut-finder function（宇宙飛行士検索 function）を作ろう
+
+これから `astronaut-finder` function（宇宙飛行士検索 function）を作ります。国際宇宙ステーション（ISS）にいる宇宙飛行士の名前をランダムに引っ張ってくるfunctionです。
+
+```
+$ faas-cli new --lang python3 astronaut-finder --prefix="<DockerHubのユーザー名>"
+```
+
+上のコマンドを実行すると３つのファイルが生成されます：
+
+```
+./astronaut-finder/handler.py
+```
+
+これはfunctionのハンドラです。 `req` オブジェクトには生のリクエストが渡ってくるので、これをコンソールに出力することができます。
+
+```
+./astronaut-finder/requirements.txt
+```
+
+`pip` モジュールとして含めておきたいモジュール名のリストです。例えば `requests` や `urllib` を記載します。
+
+```
+./astronaut-finder.yml
+```
+
+このファイルでfunctionの管理をします。functionの名前であったり、Dockerイメージ名や他にもカスタマイズしたい情報はここに記載します。
+
+*  `./astronaut-finder/requirements.txt` に以下を記載しましょう
+
+```
+requests
+```
+
+これを記載することで、サードパーティの [requests](http://docs.python-requests.org/en/master/) というモジュールが必要だということを宣言します。HTTPで様々なWebサイトをアクセスするために使います。
+
+* functionのコーディングをしましょう：
+
+データはこちらから取得します: http://api.open-notify.org/astros.json
+
+レスポンスのサンプルは以下のとおり:
+
+```json
+{"number": 6, "people": [{"craft": "ISS", "name": "Alexander Misurkin"}, {"craft": "ISS", "name": "Mark Vande Hei"}, {"craft": "ISS", "name": "Joe Acaba"}, {"craft": "ISS", "name": "Anton Shkaplerov"}, {"craft": "ISS", "name": "Scott Tingle"}, {"craft": "ISS", "name": "Norishige Kanai"}], "message": "success"}
+```
+
+ `handler.py` を編集しましょう:
+
+```python
+import requests
+import random
+
+def handle(req):
+    r = requests.get("http://api.open-notify.org/astros.json")
+    result = r.json()
+    index = random.randint(0, len(result["people"])-1)
+    name = result["people"][index]["name"]
+
+    return "%s is in space" % (name)
+```
+
+> 注: この例では `req` を使いませんが、functionの引数としては残しておきます。
+
+functionをビルドしましょう:
+
+```
+$ faas-cli build -f ./astronaut-finder.yml
+```
+
+> 注：astronaut-finder.ymlを `stack.yml` にリネームすることで、上のコマンドでは `-f` を省略することができます。CLIがデフォルトで探すファイルが `stack.yml`  であるためです。
+
+functionをデプロイしましょう:
+
+```
+$ faas-cli deploy -f ./astronaut-finder.yml
+```
+
+functionを実行してみましょう：
+
+```
+$ echo | faas-cli invoke astronaut-finder
+Anton Shkaplerov is in space
+
+$ echo | faas-cli invoke astronaut-finder
+Joe Acaba is in space
+```
+
+## トラブルシュート：コンテナのログを探そう
+
+functionがいつごろ呼ばれたか、というのはコンテナのログから確認することができます：
+
+```
+$ docker service logs -f astronaut-finder
+astronaut-finder.1.1e1ujtsijf6b@nuc    | 2018/02/21 14:53:25 Forking fprocess.
+astronaut-finder.1.1e1ujtsijf6b@nuc    | 2018/02/21 14:53:26 Wrote 18 Bytes - Duration: 0.063269 seconds
+```
+
+## トラブルシュート： `write_debug` を使ってデバッグしてみよう
+
+functionのログ出力を増やしてみましょう。functionのログを溢れさせないためにもこの機能はデフォルトでは無効化してあります。特にバイナリデータをレスポンスで返すfunctionなどでは、意味のない文字列が大量に出力されてしまうからです。
+
+以下が通常のYAMLファイルです：
+
+```yaml
+provider:
+  name: faas
+  gateway: http://127.0.0.1:8080
+
+functions:
+  astronaut-finder:
+    lang: python3
+    handler: ./astronaut-finder
+    image: astronaut-finder
+```
+
+YAMLに「environment」のセクションを追加して以下のようにしましょう：
+
+```yaml
+  astronaut-finder:
+    lang: python3
+    handler: ./astronaut-finder
+    image: astronaut-finder
+    environment:
+      write_debug: true
+```
+
+では、再び次のコマンドでデプロイします。  `faas-cli deploy -f ./astronaut-finder.yml`
+
+functionを実行してからまたログを確認してみましょう：
+
+```
+$ docker service logs -f astronaut-finder
+astronaut-finder.1.1e1ujtsijf6b@nuc    | 2018/02/21 14:53:25 Forking fprocess.
+astronaut-finder.1.szobw9pt3m60@nuc    | 2018/02/26 14:49:57 Query  
+astronaut-finder.1.szobw9pt3m60@nuc    | 2018/02/26 14:49:57 Path  /function/hello-openfaas
+astronaut-finder.1.1e1ujtsijf6b@nuc    | 2018/02/21 14:53:26 Hello World
+astronaut-finder.1.1e1ujtsijf6b@nuc    | 2018/02/21 14:53:26 Duration: 0.063269 seconds
+```
+
+### 複数のfunctionの管理
+
+CLIのYAMLでは複数のfunctionをグルーピングして一つのスタックとして管理することができます。こうすることで関連し合うfunctionを一元管理することができます。
+
+2つのfunctionを作ってみて実際にみてみましょう:
+
+```
+$ faas-cli new --lang python3 first
+```
+
+2個目のfunctionでは `--append` フラグを使いましょう：
+
+```
+$ faas-cli new --lang python3 second --append=./first.yml
+```
+
+わかりやすくするために `first.yml` を `example.yml` にリネームしましょう。
+
+```
+$ mv first.yml example.yml
+```
+
+それでは中身をみてみましょう:
+
+```
+provider:
+  name: faas
+  gateway: http://127.0.0.1:8080
+
+functions:
+  first:
+    lang: python3
+    handler: ./first
+    image: first
+  second:
+    lang: python3
+    handler: ./second
+    image: second
+```
+
+以下のフラグもfunctionを管理していく上で便利です：
+
+* ビルドの並列実行：
+
+```sh
+$ faas-cli build -f ./example.yml --parallel=2
+```
+
+* ビルドまたはプッシュを一つのfunctionに絞り込む：
+
+```sh
+$ faas-cli build -f ./example.yml --filter=second
+```
+
+他にも `faas-cli build --help` や `faas-cli push --help` をCLIで実行することでオプションを確認することができます。
+
+> 注: CLIがデフォルトで探しにいくファイルは `stack.yml` です。 `-f` パラメータでファイルを指定するのが煩わしい場合は活用しましょう。
+
+デプロイ対象のfunctionのYAMLはHTTP(s)ごしでも指定することができます `faas-cli -f https://....`。
+
+### サードパーティ製のテンプレートを使ってみよう
+
+自分で作ったfunctionの言語テンプレートがある場合やPHPテンプレートのようにコミュニティが作ったテンプレートを見つけた場合、次のコマンドで使用することができます：
+
+```
+$ faas-cli template pull https://github.com/itscaro/openfaas-template-php
+
+...
+
+$ faas-cli new --list | grep php
+- php
+- php5
+```
+
+コミュニティで管理しているテンプレートの一覧は[OpenFaaS CLIのREADME](https://github.com/openfaas/faas-cli)に記載されています。
+
+それでは、おまけのワークショップにこのまま進むか、次の [Lab 4](lab4.md) に進みましょう。
+
+### カスタムバイナリをfunctionに (任意のワークショップ)
+
+カスタムバイナリであったりコンテナをfunctionとして使うこともできます。ただし、ほとんどの場合すでに用意されている言語のテンプレートで要件は満たせるはずです。
+
+カスタムバイナリまたはDockerfileを作るには言語に `dockerfile` を指定します：
+
+```
+$ faas-cli new --lang dockerfile sorter --prefix="<DockerHubのユーザー名>"
+```
+
+`sorter` というディレクトリと `sorter.yml` が生成されます。
+
+`sorter/Dockerfile` を開いて `fprocess` の行を編集します。ここにbashの `sort` コマンドを記載しましょう。このfunctionで文字列の一覧を昇順に並べ替えることができます。
+
+```
+ENV fprocess="sort"
+```
+
+では build, push そして deployしましょう：
+
+```
+$ faas-cli build -f sorter.yml \
+  && faas-cli push -f sorter.yml \
+  && faas-cli deploy -f sorter.yml
+```
+
+UIまたはCLIからfunctionを実行しましょう：
+
+```
+$ echo -n '
+elephant
+zebra
+horse
+ardvark
+monkey'| faas-cli invoke sorter
+
+ardvark
+elephant
+horse
+monkey
+zebra
+```
+
+この例では [BusyBox](https://busybox.net/downloads/BusyBox.html) の `sort` を使いましたが、他にも `sha512sum` だったり `bash` やシェルスクリプトもあります。さらに、こういった元からあるバイナリだけでなく、どんなバイナリあるいはコンテナであってもOpenFaaSのwatchdogと連携することでサーバーレスfunctionになることができます。
+
+> 注: OpenFaaSはWindowsバイナリもサポートしています。C#、VB、Powershellなどもfunctionで使えます
+
+それでは [Lab 4](lab4.md) に進みましょう。

--- a/translations/ja/lab4.md
+++ b/translations/ja/lab4.md
@@ -1,0 +1,284 @@
+# Lab 4 - functionについてさらに掘り下げてみよう
+
+<img src="https://github.com/openfaas/media/raw/master/OpenFaaS_Magnet_3_1_png.png" width="500px"></img>
+
+このラボを始める前に作業用のディレクトリを作成しましょう：
+
+```
+$ cp -r lab3 lab4 \
+   && cd lab4
+```
+
+## 環境変数で任意の値を注入
+
+functionの挙動を実行時に変える方法があると何かと便利です。少なくとも次の2種類の方法で実現することができます：
+
+### デプロイ時
+
+* デプロイ時に環境変数を注入する
+
+これは先程 [Lab 3](./lab3.md) で `write_debug` を使ったときの手法です。同じやり方で任意の環境変数の値を設定することができます。例えば *hello world* functionを多言語対応したい場合に `spoken_language` という環境変数を用いることができます。
+
+### クエリ文字列やヘッダなどのHTTPコンテキストを活用してみよう
+
+* クエリ文字列やHTTPヘッダを使う
+
+違う方法かつより動的な方法としてはクエリ文字列やHTTPヘッダを使う、というものがあります。これはリクエスト毎に挙動を変えることができますし、 `faas-cli` あるいは `curl` の双方で使えます。
+
+これらのヘッダは環境変数を通してアクセスできるので、functionから使うのは簡単です。ヘッダはすべて `Http_` プレフィックスがついて、 `-` ハイフンは `_` アンダースコアに変換されます。
+
+では、クエリ文字列を使ってみて、環境変数を一覧表示するfunctionを実行してみましょう。
+
+* 環境変数を一覧表示してくれるfunctionをデプロイします（BusyBoxを内蔵しています）。
+
+```
+$ faas-cli deploy --name env --fprocess="env" --image="functions/alpine:latest" --network=func_functions
+```
+
+functionをクエリ文字列付きで実行してみましょう：
+
+```
+$ echo "" | faas-cli invoke env --query workshop=1
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+HOSTNAME=05e8db360c5a
+fprocess=env
+HOME=/root
+Http_Connection=close
+Http_Content_Type=text/plain
+Http_X_Call_Id=cdbed396-a20a-43fe-9123-1d5a122c976d
+Http_X_Forwarded_For=10.255.0.2
+Http_X_Start_Time=1519729562486546741
+Http_User_Agent=Go-http-client/1.1
+Http_Accept_Encoding=gzip
+Http_Method=POST
+Http_ContentLength=-1
+Http_Path=/function/env
+...
+Http_Query=workshop=1
+...
+```
+
+Pythonであれば `os.getenv("Http_Query")` でこの値を取得できます。
+
+* HTTPヘッダ付きで実行します
+
+```
+$ echo "" | curl http://127.0.0.1:8080/function/env --header "X-Output-Mode: json"
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+HOSTNAME=05e8db360c5a
+fprocess=env
+HOME=/root
+Http_X_Call_Id=8e597bcf-614f-4ca5-8f2e-f345d660db5e
+Http_X_Forwarded_For=10.255.0.2
+Http_X_Start_Time=1519729577415481886
+Http_Accept=*/*
+Http_Accept_Encoding=gzip
+Http_Connection=close
+Http_User_Agent=curl/7.55.1
+Http_Method=GET
+Http_ContentLength=0
+Http_Path=/function/env
+...
+Http_X_Output_Mode=json
+...
+```
+
+Pythonであれば `os.getenv("Http_X_Output_Mode")` でこの値を取得できます。
+
+上の結果をみてもわかるように、`Content-Length` や `Http_Method` 、それに `User_Agent` や `Cookie` など、通常のHTTPリクエストと同様の情報が取得できます。
+
+## ログの活用方法
+
+OpenFaaSのwatchdogは受信したHTTPリクエストを標準入力（ `stdin` ）に渡し、標準出力（ `stdout` ）に返ってきたものをHTTPレスポンスとして返します。つまり、実装が必要なハンドラの部分はwebのことやHTTPのことを意識する必要はありません。
+
+では、標準エラー出力を使った場合どうなるでしょうか？
+実はデフォルトでは `stdout/stderr` の内容は結合されて、 `stderr` はfunctionのログには出力されません。
+
+[Lab 3](./lab3.md) の `hello-openfaas` で実際に見てみましょう。
+
+`handler.py` を以下の内容にします
+
+```python
+import sys
+import json
+
+def handle(req):
+
+    sys.stderr.write("This should be an error message.\n")
+    return json.dumps({"Hello": "OpenFaaS"})
+```
+
+buildしてdeployしましょう
+
+```sh
+$ faas-cli build -f hello-openfaas.yml \
+  && faas-cli push -f hello-openfaas.yml \
+  && faas-cli deploy -f hello-openfaas.yml
+```
+
+では、functionを呼び出してみましょう
+
+```sh
+$ echo | faas-cli invoke hello-openfaas
+```
+
+`stderr` の内容が結合された結果になるのがわかります
+
+```
+This should be an error message.
+{"Hello": "OpenFaaS"}
+```
+
+> 注： `docker service logs hello-openfaas` を見ると、コンテナのログには `stderr` の内容が出力されていないのが確認できます
+
+このままでは `stderr` が原因でfunctionの戻り値は無効なJSONの形になってしまいます。よって、 `stderr` の中身は戻り値には結合せず、コンテナのログにだけ出力するように挙動を変えたいです。これを実現するために `combine_output` フラグを設定することができます。
+
+では、実際に `hello-openfaas.yaml` に設定してみましょう：
+
+```yaml
+    environment:
+      combine_output: false
+```
+
+push, deployしてfunctionを呼び出してみましょう。
+
+結果は下のようになります：
+
+```
+{"Hello": "OpenFaaS"}
+```
+
+functionのコンテナのログを見てみましょう。以下のように表示されているのが確認できます：
+
+```
+hello-openfaas.1.2xtrr2ckkkth@linuxkit-025000000001    | 2018/04/03 08:35:24 stderr: This should be an error message.
+```
+
+## ワークフローを作ってみよう
+
+あるfunctionの出力を違うfunctionの入力として使いたい場合がでてきます。これはクライアント側からもできれば、API Gatewayを経由して実現することもできます。
+
+### クライアント側でfunctionを連鎖させよう
+
+functionの結果は `curl`  や `faas-cli` 、あるいは自分の作ったコードのクライアントからも他のfunctionへ渡すことができます：
+
+良い点：
+
+* functionに追加のコードが必要ない - CLIでできる
+* 素早く開発・テストができる
+* 一つ一つのfunctionがモデリングしやすい
+
+悪い点：
+
+* レイテンシーが増す - functionを呼ぶ度にクライアントからサーバーの往復が発生する
+* 飛び交うメッセージ量が不必要に増加する
+
+例：
+
+* NodeInfo functionを *Function Store* からデプロイ
+* NodeInfoの結果をMarkdown functionに渡して変換
+
+```sh
+$ echo -n "" | faas-cli invoke nodeinfo | faas-cli invoke markdown
+<p>Hostname: 64767782518c</p>
+
+<p>Platform: linux
+Arch: x64
+CPU count: 4
+Uptime: 1121466</p>
+```
+
+NodeInfo functionの結果にHTMLタグ（ `<p>` ）が付加されているのが確認できます。
+
+他にクライアント側での連鎖の例として、画像を生成するfunctionを呼び出して、その画像にウォーターマークを付加するfunctionを連鎖させるというものもあるでしょう。
+
+### function内で別のfunctionを呼び出してみよう
+
+functionから他のfunctionを呼ぶ最も簡単な方法はHTTPでOpenFaaSの *API Gateway* を呼ぶ方法です。この呼出しには外部ドメイン名やIPアドレスは必要ありません。SwarmのDNSエントリがあるので単純に `gateway` を指定するだけで大丈夫です。
+
+API gatewayなどの他のサービスをfunctionから使う場合はホスト名を環境変数で持たせることがベストプラクティスです。ホスト名が将来変わるかもしれないということと、Kubernetesの場合はサフィックス（ `gateway.xxx` ）が必要になることがあるからです。
+
+良い点：
+
+* function同士で相互作用が可能になる
+* クライアントに毎回リクエストが戻る必要がなく、ほとんどの場合同じネットワーク内でfunction同士が動いているので低レイテンシーとなる
+
+悪い点：
+
+* functionがHTTPリクエストを行う必要があるので、そのためのライブラリが必要となる
+
+例：
+
+Lab 3では requests モジュールを使って外部のAPIを呼び出し、国際宇宙ステーションの宇宙飛行士を取得する方法をワークショップをやりました。これと同じ方法でOpenFaaSの別のfunctionを呼び出すことができます。
+
+* *Function Store* から *Sentiment Analysis* function をデプロイしてください
+
+Sentiment Analysis functionは与えられた（英語の）文章に対して主観性と（ポジティブかどうかの）極性を数値で返します。結果のJSONは下の例のようになります：
+
+```sh
+$ echo -n "California is great, it's always sunny there." | faas-cli invoke sentimentanalysis
+{"polarity": 0.8, "sentence_count": 1, "subjectivity": 0.75}
+```
+
+この結果から上の文章はとても主観的（75%）でポジティブ（80%）だということがわかります。これらの値は必ず `-1.00` から `1.00` の値をとります。
+
+以下のようなコードで他のfunctionから *Sentiment Analysis* function を呼び出すことができます：
+
+```python
+    test_sentence = "California is great, it's always sunny there."
+    r = requests.get("http://gateway:8080/function/sentimentanalysis", text= test_sentence)
+```
+
+また、環境変数を使った場合は次のようになります:
+
+```python
+    gateway_hostname = os.getenv("gateway_hostname", "gateway") # gateway_hostnameという環境変数が無い場合はデフォルト値の"gateway"に設定
+    test_sentence = "California is great, it's always sunny there."
+    r = requests.get("http://" + gateway_hostname + ":8080/function/sentimentanalysis", text= test_sentence)
+```
+
+結果は必ずJSONで返ってくるとわかっているので `.json()` というヘルパー関数を使ってレスポンスを変換します：
+
+```python
+    result = r.json()
+    if result["polarity"] > 0.45:
+        print("That was probably positive")
+    else:
+        print("That was neutral or negative")
+```
+
+では、新しいfunctionをPythonで作って全部組み合わせてみましょう
+
+```python
+import os
+import requests
+import sys
+
+def handle(req):
+    """handle a request to the function
+    Args:
+        req (str): request body
+    """
+
+    gateway_hostname = os.getenv("gateway_hostname", "gateway") # gateway_hostnameという環境変数が無い場合はデフォルト値の"gateway"に設定
+
+    test_sentence = req
+
+    r = requests.get("http://" + gateway_hostname + ":8080/function/sentimentanalysis", data= test_sentence)
+
+    if r.status_code != 200:
+        sys.exit("Error with sentimentanalysis, expected: %d, got: %d\n" % (200, r.status_code))
+
+
+    result = r.json()
+    if result["polarity"] > 0.45:
+        print("That was probably positive")
+    else:
+        print("That was neutral or negative")
+```
+
+* `requirements.txt` に `requests` を記載するのを忘れないでください
+
+> 注: SentimentAnalysis functionの編集は特に必要ありません。既にfunction storeからデプロイ済みですし、API gateway経由で呼び出します。
+
+それでは [Lab 5](lab5.md) に進みましょう。

--- a/translations/ja/lab5.md
+++ b/translations/ja/lab5.md
@@ -1,0 +1,351 @@
+# Lab 5 - Gitbotを作ろう
+
+<img src="https://github.com/openfaas/media/raw/master/OpenFaaS_Magnet_3_1_png.png" width="500px"></img>
+
+このラボを始める前に作業用のディレクトリを作成しましょう：
+
+```
+$ mkdir -p lab5 \
+   && cd lab5
+```
+
+このワークショップでは今まで学んだことを応用して `issue-bot` というGitHubのBotをOpenFaaSのfunctionで作ります。
+
+issue-botを使ってGitHub Issueの感情を分析し、 *positive* または *review* というラベルを付与します。こうすることで普段忙しいであろうリポジトリのメンテナーたちにとってどのIssueを優先して見たほうがいいかという手助けになります。
+
+![](../../diagram/issue-bot.png)
+
+## GitHubのアカウントを取得
+
+* [GitHubのアカウント](https://github.com)を持っていない場合はアカウント登録をしてください。
+* 新しいリポジトリを *bot-tester* という名前で作ります。
+
+> 注：このリポジトリはこのワークショップのIssueのテストに使うだけなので、ここにコードをコミットする必要はありません。
+
+## ngrokでトンネルを作る
+
+GitHubからwebhookを受け取る必要があります。本番環境であればインターネットからリクエストを受け取る環境が整っているかと思いますが、ワークショップや開発環境レベルではなかなかそうもいかないので工夫が必要です。
+
+ターミナルを開いて次のコマンドを入力しましょう：
+
+```
+$ docker run -p 4040:4040 -d --name=ngrok --net=func_functions \
+  alexellis2/ngrok-admin http gateway:8080
+```
+
+`ngrok` の標準で備わっているUIに http://127.0.0.1:4040 でアクセスして、生成されたHTTPのURLを確認しましょう。このURLを使ってインターネットから直接OpenFaaSのAPI Gatewayにアクセスできます。
+
+> 注: `ngrok` は JSON API も `http://127.0.0.1:4040/api/tunnels` で公開しています
+
+URLを試してみましょう（http://fuh83fhfj.ngrok.io だった場合の例です）
+
+```
+$ faas-cli list --gateway http://fuh83fhfj.ngrok.io/
+```
+
+## webhookを受け取れる `issue-bot` を作る
+
+```
+$ faas-cli new --lang python3 issue-bot --prefix="<DockerHubのユーザー名>"
+$ faas-cli build -f ./issue-bot.yml
+$ faas-cli push -f ./issue-bot.yml
+```
+
+functionのYAMLファイル `issue-bot.yml` を開いて `write_debug: true` という環境変数を増やしましょう：
+
+```
+provider:
+  name: faas
+  gateway: http://127.0.0.1:8080
+
+functions:
+  issue-bot:
+    lang: python3
+    handler: ./issue-bot
+    image: <DockerHubのユーザー名>/issue-bot
+    environment:
+      write_debug: true
+```
+
+* functionをデプロイします
+
+```
+$ faas-cli deploy -f ./issue-bot.yml
+```
+
+## GitHubからwebhookを受け取る
+
+GitHubに戻って先程作った *bot-tester* を開きます
+
+*Settings* -> *Webhooks* -> *Add Webhook* をクリックします
+
+![](../../screenshot/add_github_webhook.png)
+
+ここで先程の `ngrok` のURLを入力し、末尾に `/function/issue-bot` を追記します。次のようになります：
+
+```
+http://fuh83fhfj.ngrok.io/function/issue-bot
+```
+
+![](https://raw.githubusercontent.com/iyovcheva/github-issue-bot/master/media/WebhookURLSettings.png)
+
+*Content-type* には *application/json* を選択
+
+*Secret* は今のところ空白
+
+"Let me select individual events" を選択
+
+イベントは **Issues** と **Issue comment** を選択
+
+![](https://raw.githubusercontent.com/iyovcheva/github-issue-bot/master/media/WebhookEventsSettings.png)
+
+## webhookの動作確認
+
+それではGitHubのリポジトリで新しいIssueを作りましょう。titleもdescriptionも「test」と入力します。
+
+functionが何回呼ばれたか確認しましょう - 少なくとも `1回` は呼ばれているはずです。
+
+```
+$ faas-cli list
+Function    Invocations
+issue-bot   2
+```
+
+Issueを作る度にGitHubのAPIがfunctionを呼ぶので回数が増えていきます。
+
+GitHubからのリクエストのペイロードは `docker service logs -f issue-bot` で確認することができます。
+
+GitHubのWebhooksページでも「Recent Deliveries」の下で今までのメッセージの履歴を確認できます。ここでwebhookを再実行して function からのレスポンスを確認することもできます。
+
+![](../../screenshot/github_replay.png)
+
+### Sentiment Analysis functionのデプロイ
+
+issue-bot functionを使うにはまず SentimentAnalysis functionをデプロイする必要があります。このfunctionはPythonで書かれていて、与えられた（英語の）文章に対してポジティブかどうか（極性 -1.0 - 1.0）と、主観的かどうかという感情の指標を返します。
+
+「SentimentAnalysis」は **Function Store** からデプロイできます。
+
+```
+$ echo -n "I am really excited to participate in the OpenFaaS workshop." | faas-cli invoke sentimentanalysis
+Polarity: 0.375 Subjectivity: 0.75
+
+$ echo -n "The hotel was clean, but the area was terrible" | faas-cli invoke sentimentanalysis
+Polarity: -0.316666666667 Subjectivity: 0.85
+```
+
+### `issue-bot` function を編集しましょう
+
+`issue-bot/handler.py` を開いて次のコードに置き換えます：
+
+```python
+import requests, json, os, sys
+
+def handle(req):
+
+    event_header = os.getenv("Http_X_Github_Event")
+
+    if not event_header == "issues":
+        sys.exit("Unable to handle X-GitHub-Event: " + event_header)
+        return
+
+    gateway_hostname = os.getenv("gateway_hostname", "gateway")
+
+    payload = json.loads(req)
+
+    if not payload["action"] == "opened":
+        return
+
+    #sentimentanalysis
+    res = requests.post('http://' + gateway_hostname + ':8080/function/sentimentanalysis', data=payload["issue"]["title"]+" "+payload["issue"]["body"])
+
+    if res.status_code != 200:
+        sys.exit("Error with sentimentanalysis, expected: %d, got: %d\n" % (200, res.status_code))
+
+    return res.json()
+```
+
+`requirements.txt` にHTTP/HTTPSリクエストで必要になる requests モジュールを追加します：
+
+```
+requests
+```
+
+下のコードの部分でGitHubのIssueのtitleとbodyを `sentimentanalysis` function にテキストでPostしています。レスポンスはJSONで返ってきます。
+
+```python
+res = requests.post('http://' + gateway_hostname + ':8080/function/sentimentanalysis', data=payload["issue"]["title"]+" "+payload["issue"]["body"])
+```
+
+* buildとdeploy
+
+CLIを使ってfunctionのbuildとdeployをしましょう：
+
+```
+$ faas-cli build -f issue-bot.yml \
+  && faas-cli push -f issue-bot.yml \
+  && faas-cli deploy -f issue-bot.yml
+```
+
+それでは `bot-tester` リポジトリに新しいIssueを作ってみましょう。GitHubはJSONのペイロードを上で作ったNgrokのトンネルを経由して function に渡します。
+
+このリクエストとレスポンスはGitHubの *Settings* -> *Webhook* のページで確認できます：
+
+![](https://raw.githubusercontent.com/iyovcheva/github-issue-bot/master/media/WebhookResponse.png)
+
+## GitHubに応答する
+
+次に `positive` か `review` のラベルを付与したいのですが、これにはリポジトリへの書き込み権限が必要になります。そのため、 *Personal Access Token* をGitHubで取得する必要があります。
+
+### Personal Access TokenをGitHubで作る
+
+*GitHub profile* -> *Settings/Developer settings* -> *Personal access tokens* で *Generate new token* をクリックします。
+
+![](https://raw.githubusercontent.com/iyovcheva/github-issue-bot/master/media/PersonalAccessTokens.png)
+
+「repo」にチェックを入れてリポジトリへのアクセス権を付与します。
+
+![](https://raw.githubusercontent.com/iyovcheva/github-issue-bot/master/media/NewPAT.png)
+
+ページ下部の「Generate Token」ボタンをクリックします。
+
+`env.yml` というファイルを `issue-bot.yml` と同じ場所に作ります。中に以下の内容を貼り付けましょう：
+
+```yaml
+environment:
+  auth_token: <auth_token_value>
+```
+
+`auth_token` の値にはGitHubが発行したトークンを入力します。
+
+それでは `issue-bot.yml` ファイルを開いて `env.yml` を使うように編集しましょう：
+
+```yaml
+provider:
+  name: faas
+  gateway: http://127.0.0.1:8080
+
+functions:
+  issue-bot:
+    lang: python3
+    handler: ./issue-bot
+    image: <DockerHubのユーザー名>/issue-bot
+    environment:
+      write_debug: true
+      gateway_hostname: "gateway"
+      positive_threshold: 0.25
+    environment_file:
+    - env.yml
+```
+
+> ここで `positive_threshold` という環境変数にはいい具合に `positive` と `review` のラベルを振り分けれるようにあらかじめ調整した最適と思われる値を入れています。
+
+機密性の高い情報は外部ファイル（例： `env.yml` ）で保持しておくべきです。このファイルを `.gitignore` に記載しておくことで、パブリックなGitリポジトリに誤って機密情報をアップロードしてしまわないようにできます。
+
+OpenFaaSではDockerやKubernetesのSecretを使う機能が備わっています。詳細については [Lab10](./lab10.md) を参照してください。
+
+### GitHub APIを使ってラベルを適用する方法
+
+PyGithubというPythonのライブラリがあり、GitHubのAPIを使って様々なことを簡単にできます。使い方のドキュメントは [こちら](https://github.com/PyGithub/PyGithub) にあります。
+
+以下のようなコードでリポジトリやIssueの情報を取得できます（まだこのコードは function に追加しないでください）。
+
+```python
+issue_number = 1
+repo_name = "alexellis/issue_bot"
+auth_token = "xyz"
+
+g = Github("auth_token")
+repo = g.get_repo(repo_name)
+issue = repo.get_issue(issue_number)
+```
+
+このライブラリはGitHub公式ではないのですが、広く使われているようです。 `requirements.txt` に記載して `pip` で取得できるようにしましょう。
+
+## functionの仕上げ
+
+* `issue-bot/requirements.txt` ファイルを開いて `PyGithub` を追加しましょう
+
+```
+requests
+PyGithub
+```
+
+* `issue-bot/handler.py` を開いて次のようにコードを更新します：
+
+```python
+import requests, json, os, sys
+from github import Github
+
+def handle(req):
+    event_header = os.getenv("Http_X_Github_Event")
+
+    if not event_header == "issues":
+        sys.exit("Unable to handle X-GitHub-Event: " + event_header)
+        return
+
+    gateway_hostname = os.getenv("gateway_hostname", "gateway")
+
+    payload = json.loads(req)
+
+    if not payload["action"] == "opened":
+        sys.exit("Action not supported: " + payload["action"])
+        return
+
+    # sentimentanalysis functionの呼び出し
+    res = requests.post('http://' + gateway_hostname + ':8080/function/sentimentanalysis', 
+                        data= payload["issue"]["title"]+" "+payload["issue"]["body"])
+
+    if res.status_code != 200:
+        sys.exit("Error with sentimentanalysis, expected: %d, got: %d\n" % (200, res.status_code))
+
+    # 環境変数から positive_threshold を読み込む
+    positive_threshold = float(os.getenv("positive_threshold", "0.2"))
+
+    polarity = res.json()['polarity']
+
+    # ラベルを適用するためにGitHubのAPIを使う
+    apply_label(polarity,
+        payload["issue"]["number"],
+        payload["repository"]["full_name"],
+        positive_threshold)
+
+    print("Repo: %s, issue: %s, polarity: %f" % (payload["repository"]["full_name"], payload["issue"]["number"], polarity))
+
+def apply_label(polarity, issue_number, repo, positive_threshold):
+    g = Github(os.getenv("auth_token"))
+    repo = g.get_repo(repo)
+    issue = repo.get_issue(issue_number)
+
+    has_label_positive = False
+    has_label_review = False
+    for label in issue.labels:
+        if label == "positive":
+            has_label_positive = True
+        if label == "review":
+            has_label_review = True
+
+    if polarity > positive_threshold and not has_label_positive:
+        issue.set_labels("positive")
+    elif not has_label_review:
+        issue.set_labels("review")
+```
+
+> このソースコードは[issue-bot/bot-handler/handler.py](../../issue-bot/bot-handler/handler.py) にも公開しています
+
+* build して deploy
+
+CLIを使ってfunctionをbuildしてdeployします：
+
+```
+$ faas-cli build -f issue-bot.yml \
+  && faas-cli push -f issue-bot.yml \
+  && faas-cli deploy -f issue-bot.yml
+```
+
+それでは `bot-tester` のリポジトリにIssueを作ってテストしてみましょう。 `positive` または `review` のラベルが付与されるかどうか確認しましょう。正常に動作しない場合はGitHubのWebhooksのページでメッセージを確認し、エラーが発生していないかみてみましょう。
+
+![](../../screenshot/bot_label_applied.png)
+
+> 注：ラベルがリアルタイムで付与されない場合はブラウザを再読込してみてください
+
+それでは [Lab 6](lab6.md) に進みましょう。

--- a/translations/ja/lab6.md
+++ b/translations/ja/lab6.md
@@ -1,0 +1,313 @@
+# Lab 6 - functionでHTMLを扱ってみよう
+
+<img src="https://github.com/openfaas/media/raw/master/OpenFaaS_Magnet_3_1_png.png" width="500px"></img>
+
+このラボを始める前に作業用のディレクトリを作成しましょう：
+
+```
+$ mkdir -p lab6 \
+   && cd lab6
+```
+
+## 簡単なHTMLをfunctionから返す
+
+functionではHTMLを生成して返すことができます。また、ヘッダの `Content-Type` を `text/html` とすることも可能なので、ブラウザで表示させることもできます。HTMLを生成して返す簡単なfunctionを作ってみましょう。
+
+```
+$ faas-cli new --lang python3 show-html --prefix="<Docker Hubのユーザー名>"
+```
+
+`handler.py` を編集します:
+
+```python
+def handle(req):
+    """handle a request to the function
+    Args:
+        req (str): request body
+    """
+
+    html = '<html><h2>Hi, from your function!</h2></html>'
+
+    return html
+
+```
+
+これで呼び出し元にHTMLを返すことができます。続いて、 `Content-Type` を設定しましょう。このfunctionは必ずHTMLを返すので、 `Content-Type` は `text/html` にするべきです。これは `show-html.yml` の  `environment` で設定することができます。
+
+`show-html.yml` を編集します：
+
+```yams
+provider:
+  name: faas
+  gateway: http://127.0.0.1:8080
+
+functions:
+  show-html:
+    lang: python3
+    handler: ./show-html
+    image: <Docker Hubのユーザー名>/show-html
+    environment:
+      content_type: text/html
+
+```
+
+`content_type` キーに設定した値が `Content-Type` としてレスポンスで設定されます。
+
+それではfunctionのbuild, push, deployをしましょう：
+
+```
+$ faas-cli build -f show-html.yml \
+  && faas-cli push -f show-html.yml \
+  && faas-cli deploy -f show-html.yml
+```
+
+ブラウザを開いて http://127.0.0.1:8080/function/show-html にアクセスしましょう。functionで生成したHTMLが表示されているのが確認できます。
+
+## HTMLファイルを読み込んで返すfunction
+
+HTMLを配信したいとき、ほとんどの場合静的なHTMLをあらかじめ準備しているはずです。次のfunctionではHTMLファイルをfunctionのコンテナに内包して配信してみましょう。
+
+まずはHTMLファイルを作ります。
+
+`html` というディレクトリを作ってその中に `new.html` というファイルを作りましょう。次のような構造になります：
+
+```
+├── show-html
+│   ├── __init__.py
+│   ├── handler.py
+│   ├── html
+│   │   └── new.html
+│   └── requirements.txt
+└── show-html.yml
+```
+
+ `new.html`  を編集します：
+
+```html
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+  <meta charset='UTF-8'>
+  <title>OpenFaaS</title>
+</head>
+<body>
+  <h2>Here's a new page!</h2>
+</body>
+</html>
+```
+
+次に `handler.py` を以下のようにします：
+
+```python
+import os
+
+def handle(req):
+    """handle a request to the function
+    Args:
+        req (str): request body
+    """
+
+    dirname = os.path.dirname(__file__)
+    path = os.path.join(dirname, 'html', 'new.html')
+
+    with(open(path, 'r')) as file:
+        html = file.read()
+
+    return html
+
+```
+
+functionをbuild、push、deployしましょう：
+
+```
+$ faas-cli build -f show-html.yml \
+  && faas-cli push -f show-html.yml \
+  && faas-cli deploy -f show-html.yml
+```
+
+ブラウザを開いて http://127.0.0.1:8080/function/show-html にアクセスしましょう。ファイルであらかじめ用意していたHTMLが表示されるのが確認できます。
+
+## クエリ文字列によって配信するHTMLを切り替える
+
+functionからHTMLを配信する方法がわかったところで、動的に配信するHTMLをクエリ文字列で切り替える方法を試してみましょう。 [Lab 4](./lab4.md) で学んだように、クエリ文字列は `Http_Query` という環境変数で取得することができます。例えば以下のようにリクエストを受け取ったとします：
+
+ http://127.0.0.1:8080/function/show-html?action=new
+
+クエリ文字列は `action=new` なので、 `Http_Query` の値は `action=new` となります。さらに、 `urllib.parse` パッケージの `parse_qs` 関数を使うことで簡単にクエリ文字列をパースすることもできます。
+
+まずは新たに `list.html` というファイルを作りましょう。ディレクトリ構造は以下のようになります：
+
+```
+├── show-html
+│   ├── __init__.py
+│   ├── handler.py
+│   ├── html
+│   │   ├── list.html
+│   │   └── new.html
+│   └── requirements.txt
+└── show-html.yml
+```
+
+ `list.html` を編集します：
+
+```html
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+  <meta charset='UTF-8'>
+  <title>OpenFaaS</title>
+</head>
+<body>
+  <h2>This is a list!</h2>
+  <ul>
+    <li>One</li>
+    <li>Two</li>
+    <li>Three</li>
+  </ul>
+</body>
+</html>
+```
+
+`handler.py` を編集します： 
+
+```python
+import os
+from urllib.parse import parse_qs
+
+def handle(req):
+    """handle a request to the function
+    Args:
+        req (str): request body
+    """
+
+    query = os.environ['Http_Query']
+    params = parse_qs(query)
+    action = params['action'][0]
+
+    dirname = os.path.dirname(__file__)
+    path = os.path.join(dirname, 'html', action + '.html')
+
+    with(open(path, 'r')) as file:
+        html = file.read()
+
+    return html
+```
+
+functionをbuild、push、deployしましょう：
+
+```
+$ faas-cli build -f show-html.yml \
+  && faas-cli push -f show-html.yml \
+  && faas-cli deploy -f show-html.yml
+```
+
+ブラウザを開いてまずは以下にアクセスしましょう：
+
+http://127.0.0.1:8080/function/show-html?action=new
+
+「Here's a new page!」というページが先程のセクションと同じように表示されます。次に以下にアクセスします：
+
+http://127.0.0.1:8080/function/show-html?action=list
+
+リストを表示するページが確認できます。
+
+## 他のfunctionとの組み合わせ
+
+最後に、HTML、JavaScriptとAjaxを組み合わせて、他のfunctionをどのように利用できるか見てみましょう（ *figlet* functionを使います）。
+
+まず、 `figlet.html` というファイルを作ります。ディレクトリ構造は以下のようになります：
+
+```
+├── show-html
+│   ├── __init__.py
+│   ├── handler.py
+│   ├── html
+│   │   ├── figlet.html
+│   │   ├── list.html
+│   │   └── new.html
+│   └── requirements.txt
+└── show-html.yml
+```
+
+`figlet.html` を編集します：
+
+```html
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+  <meta charset='UTF-8'>
+  <title>OpenFaaS</title>
+  <script
+  src="https://code.jquery.com/jquery-3.3.1.min.js"
+  integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8="
+  crossorigin="anonymous"></script>
+  <style>
+    .result {
+        font-family: 'Roboto Mono', monospace;
+    }
+    </style>
+</head>
+<body>
+  <h2>Figlet</h2>
+  <p>
+    Text: <input type="text" name="text" id="text"> 
+    <button id="generate">Generate</button>
+  </p>
+  
+  <textarea class="result" cols="80" rows="10"></textarea>
+
+  <script type="text/javascript">
+    $(function(){
+      // Generate button click
+      $('#generate').on('click', function() {
+        // Execute ajax request
+        $.ajax({
+          url:'./figlet',
+          type:'POST',
+          data:$('#text').val()
+        })
+        .done(function(data) {
+          // ajax success
+          $('.result').val(data);
+          console.log(data);
+        })
+        .fail(function(data) {
+          // ajax failure
+          $('.result').val(data);
+          console.log(data);
+        });
+      });
+    });
+  </script>
+</body>
+</html>
+```
+
+JavaScriptについてあまりわからない人も気にしないでください。このページでやっていることは：
+
+* `input` に文字を入力して
+* `Generate` ボタンを押して
+* `figlet` functionのエンドポイント（ `/function/figlet` ）にリクエストを投げて
+* 結果を `textarea` に反映する
+
+前のセクションで配信するHTMLを動的に切り替えられるようにしているので、 `handler.py` を編集する必要はありません。ただし、追加で配信するHTML（ `figlet.html` ）をイメージに内包する必要があるので、buildとpushは必要になります。
+
+それではfunctionのbuild、push、deployをしましょう：
+
+```
+$ faas-cli build -f show-html.yml \
+  && faas-cli push -f show-html.yml \
+  && faas-cli deploy -f show-html.yml
+```
+
+ここでは [Lab 2](./lab2.md) での *figlet* functionをデプロイ済みであるとします。
+
+ブラウザを開いて以下にアクセスします：
+
+http://127.0.0.1:8080/function/show-html?action=figlet
+
+「Figlet」のページが表示されるはずです。何かしらの**英数字**を入力して「Generate」ボタンを押します。 `input` に入力した文字列がfiglet（文字のアスキーアート）となって `textarea` に反映されるはずです。このサンプルは非常に簡単な例になりますが、応用することでSPA（Single Page Application）をfunctionで作ることも可能になります。
+
+このLabではfunctionからHTMLを配信し、 `Content-Type` も設定する方法について学びました。さらに、HTML + JavaScriptを使って他のfunctionを呼び出し、動的なページを作る方法についても学びました。
+
+それでは [Lab 7](lab7.md) に進みましょう。

--- a/translations/ja/lab7.md
+++ b/translations/ja/lab7.md
@@ -1,0 +1,118 @@
+# Lab 7 - 非同期 function
+
+<img src="https://github.com/openfaas/media/raw/master/OpenFaaS_Magnet_3_1_png.png" width="500px"></img>
+
+このラボを始める前に作業用のディレクトリを作成しましょう：
+
+```
+$ mkdir -p lab7 \
+   && cd lab7
+```
+
+## 非同期 vs 同期 function
+
+同期的にfunctionを実行した場合、gatewayとfunctionは実行時間の間ずっとコネクションを張っています。同期的な呼び出しは*ブロック* が発生します。なので、呼び出し元のクライアントはfunctionが完了するまで一時停止状態になってしまいます。
+
+* gatewayは `/function/<function名>` というURLを使います
+* クライアントは実行が完了するまで待たなければいけません
+* 実行完了とともに結果がもらえます
+* 成功したかどうかはその場でわかります
+
+非同期な呼び出しは似たような動きをしますが、次の点が異なります：
+
+* gatewayのURLは `/async-function/<function名>` 
+* クライアントはfunctionの実行後すぐに *202 Accepted* をgatewayから受け取ります
+* functionはqueue-workerを通して後で実行されます
+* デフォルトでは結果は破棄されます
+
+簡単なデモを試してみましょう。
+
+```
+$ faas-cli new --lang dockerfile long-task --prefix="<DockerHubのユーザー名>"
+```
+
+`long-task/Dockerfile` を開いてfprocessを `sleep 1` に変更しましょう。
+
+build, deployしてfunctionを次のように10回、同期的に実行しましょう：
+
+```
+echo -n "" | faas-cli invoke long-task
+echo -n "" | faas-cli invoke long-task
+echo -n "" | faas-cli invoke long-task
+echo -n "" | faas-cli invoke long-task
+echo -n "" | faas-cli invoke long-task
+echo -n "" | faas-cli invoke long-task
+echo -n "" | faas-cli invoke long-task
+echo -n "" | faas-cli invoke long-task
+echo -n "" | faas-cli invoke long-task
+echo -n "" | faas-cli invoke long-task
+```
+
+それでは次に10回非同期に実行しましょう：
+
+```
+echo -n "" | faas-cli invoke long-task --async
+echo -n "" | faas-cli invoke long-task --async
+echo -n "" | faas-cli invoke long-task --async
+echo -n "" | faas-cli invoke long-task --async
+echo -n "" | faas-cli invoke long-task --async
+echo -n "" | faas-cli invoke long-task --async
+echo -n "" | faas-cli invoke long-task --async
+echo -n "" | faas-cli invoke long-task --async
+echo -n "" | faas-cli invoke long-task --async
+echo -n "" | faas-cli invoke long-task --async
+echo -n "" | faas-cli invoke long-task --async
+```
+
+いかがでしたか？最初の例は10秒ほどかかり、次の例は1秒もかからなかったのではないでしょうか。実行自体は10x1秒かかりますが、実行する責任はキューに委譲されています。
+
+非同期functionはすぐに実行しなくても良い、あるいはクライアント側で結果が必要ない場合に有用です。
+
+> 良い例として、Githubのwebhookについて考えてみましょう。Github側からはコネクションの長さに制限があるかもしれませんが、非同期functionを使うことでレスポンスをすぐに返すことができます。
+
+## queue-worker のログを見てみよう
+
+OpenFaaSのデフォルトのスタックはキューや非同期実行のためにNATS Streamingを採用しています。以下のコマンドでログを参照できます：
+
+```
+docker service logs -f func_queue-worker
+```
+
+## requestbinやngrokで `X-Callback-Url` を活用してみよう
+
+非同期functionの結果が必要な場合もあります。それには次の2種類の方法が可能です：
+
+* functionの挙動として、最後に何かしらのエンドポイントやメッセージングシステムに結果を通知させる
+
+このやり方がかならずしも良いとは限りませんし、追加のコーディングが必要になります。
+
+* OpenFaaSの標準機能であるコールバックの仕組みを使う
+
+OpenFaaSのコールバックの仕組みを使うことで、非同期functionを実行するqueue-workerが自動的に指定されたURLに結果を通知することができます。
+
+それではrequestbinを使って新しい「bin」を作ってみましょう。requestbinはインターネット上でリクエストを受け取れるサービスです。
+
+https://requestbin.fullcontact.com/
+
+「Bin URL」をコピーして次のように呼び出してみましょう。
+
+例えば `http://requestbin.fullcontact.com/1i7i1we1` の場合
+
+```
+$ echo -n "LaterIsBetter" | faas-cli invoke figlet --async --header "X-Callback-Url=http://requestbin.fullcontact.com/1i7i1we1"
+```
+
+呼び出し後、requestbinのページをリフレッシュしましょう。次のように `figlet` の結果が表示されます：
+
+```
+ _          _           ___     ____       _   _            
+| |    __ _| |_ ___ _ _|_ _|___| __ )  ___| |_| |_ ___ _ __ 
+| |   / _` | __/ _ \ '__| |/ __|  _ \ / _ \ __| __/ _ \ '__|
+| |__| (_| | ||  __/ |  | |\__ \ |_) |  __/ |_| ||  __/ |   
+|_____\__,_|\__\___|_| |___|___/____/ \___|\__|\__\___|_|   
+                                                            
+```
+
+> 注： `X-Callback-Url` には違うfunctionを指定することもできます。この仕組みを使えば完了時にSlackやEmailに非同期functionの結果を通知することができます。違うfunctionを呼ぶには `X-Callback-Url` に `http://gateway:8080/function/<function名>` を設定します。
+
+それでは [Lab 8](lab8.md) に進みましょう。

--- a/translations/ja/lab8.md
+++ b/translations/ja/lab8.md
@@ -1,0 +1,93 @@
+# Lab 8 - 応用編 - タイムアウト
+
+<img src="https://github.com/openfaas/media/raw/master/OpenFaaS_Magnet_3_1_png.png" width="500px"></img>
+
+このラボを始める前に作業用のディレクトリを作成しましょう：
+
+```
+$ mkdir -p lab8 \
+   && cd lab8
+```
+
+## `read_timeout` でタイムアウトを延ばす
+
+タイムアウトとは、functionが許容される実行時間を指します。この時間をすぎるとfunctionは強制的に停止されます。分散システムなどでAPIが悪用されないための重要な役割を果たします。
+
+functionのタイムアウトには複数の種類があり、それぞれを環境変数で設定することができます。
+
+* Function timeout
+
+
+
+* `read_timeout` - functionがHTTPリクエストを読み込むときのタイムアウト
+* `write_timout` - functionがHTTPレスポンスを書き込むときのタイムアウト
+* `exec_timeout` - functionの実行が許容される最大の時間
+
+API Gatewayにはデフォルトで20秒が設定されているので、さらに短い時間に設定してみましょう。
+
+```
+$ faas-cli new --lang python3 sleep-for --prefix="<Docker Hubのユーザー名>"
+```
+
+`handler.py` を編集します：
+
+```python
+import time
+import os
+
+def handle(req):
+    """handle a request to the function
+    Args:
+        req (str): request body
+    """
+
+    sleep_duration = int(os.getenv("sleep_duration", "10"))
+    preSleep = "Starting to sleep for %d" % sleep_duration
+    time.sleep(sleep_duration)  # Sleep for a number of seconds
+    postSleep = "Finished the sleep"
+    return preSleep + "\n" + postSleep
+```
+
+それでは `sleep-for.yml` に環境変数を設定しましょう。
+
+```yaml
+provider:
+  name: faas
+  gateway: http://127.0.0.1:8080
+
+functions:
+  sleep-for:
+    lang: python3
+    handler: ./sleep-for
+    image: <Docker Hubのユーザー名>/sleep-for:0.1
+    environment:
+      sleep_duration: 10
+      read_timeout: 5
+      write_timeout: 5
+      exec_timeout: 5
+```
+
+CLIを使ってbuild、push、deployしてからfunctionを実行してみましょう。
+
+```
+$ echo | faas-cli invoke sleep-for
+Server returned unexpected status code: 500 - Can't reach service: sleep-for
+```
+
+メッセージが返却される前に終了しているのが確認できます。
+
+それでは `sleep_duration` を `2` に設定してもっと短くしましょう。再び `faas-cli deploy` を実行します。functionのYAMLを編集した場合はリビルドの必要はありません。
+
+```
+$ echo | faas-cli invoke sleep-for
+Starting to sleep for 2
+Finished the sleep
+```
+
+* API Gateway timeout
+
+gatewayに設定するタイムアウトが最も優先されます。執筆時点ではこの値は「20s」に設定されていますが、任意の値に設定することができます。
+
+gatewayの設定を変更する場合は `docker-compose.yml` の `gateway` と `faas-swarm` の `read_timeout` や `write_timeout` の値を変更します。変更後は `./deploy_stack.sh` を実行して反映します。
+
+それでは [Lab 9](lab9.md) に進みましょう。

--- a/translations/ja/lab9.md
+++ b/translations/ja/lab9.md
@@ -1,0 +1,62 @@
+# Lab 9 - 応用編 - functionのオートスケール
+
+<img src="https://github.com/openfaas/media/raw/master/OpenFaaS_Magnet_3_1_png.png" width="500px"></img>
+
+[公式ドキュメント](http://docs.openfaas.com/architecture/autoscaling/)  でも謳われているように、OpenFaaSにはオートスケール機能があります。このLabでは実際にオートスケールが動作するのを見てみましょう。
+
+## 前準備
+
+* [Lab 1](./lab1.md) でOpenFaaSが準備できていれば準備OKです。
+* オートスケールを発動させるには様々なツールを使うことができます。ここでは `curl` を使います。Mac、Linuxでほとんどの場合使えますし、WindowsのGit Bashでも内包しています。
+
+## オートスケールの背景
+
+OpenFaaSは標準で `リクエスト/秒` の値によってオートスケールするかどうかを判断しています。これはGatewayのトラフィックをPrometheusが監視することで実現しています。 `リクエスト/秒` の上限を超えた場合にAlertManagerが発火します。本番では最適な値を検証するべきですが、今回はオートスケールを簡単に体験するためにもこの上限は低く設定します。
+
+> オートスケールの詳細については [公式ドキュメント](http://docs.openfaas.com/architecture/autoscaling/) を参照してください。
+
+アラートがAlertManagerから発火するたびにGatewayは、あらかじめ設定している数のレプリカをfunctionに対して増やします。OpenFaaSではレプリカの最小数と最大数をそれぞれラベルを使って設定することができます：
+
+レプリカの最小数は `com.openfaas.scale.min` で設定可能です。デフォルトは `1` です。
+
+レプリカの最大数は `com.openfaas.scale.max` で設定可能です。デフォルトは `20` です。
+
+> 注：`com.openfaas.scale.min` と `com.openfaas.scale.max` を同じ値に設定した場合、オートスケール機能は無効化されます。
+
+## Prometheusの確認
+
+PrometheusのUIをブラウザで開きます： `http://localhost:9090/graph`
+
+functionの成功した呼び出しのグラフを見てみましょう。 `rate(gateway_function_invocation_total{code="200"} [20s])` というクエリを実行することで確認できます。以下のようなページが確認できます：
+
+ ![](../../screenshot/prometheus_graph.png)
+
+それではアラートを見れる画面を開きましょう： `http://localhost:9090/alerts`. この画面で、 `リクエスト/秒` がいつ上限を超えたかを見ることができます。
+
+ ![](../../screenshot/prometheus_alerts.png)
+
+### NodeInfo functionでオートスケールを確認
+
+まずはstoreからnodeinfo functionをデプロイしましょう：
+
+```bash
+$ faas-cli store deploy nodeinfo
+```
+
+UIを確認してnodeinfoが有効になるのを確認しましょう。
+
+それでは、以下のスクリプトを実行して `nodeinfo` のレプリカ数が変わるまで延々と呼び続けましょう。レプリカ数はPrometheusで `gateway_service_count` というグラフを追加するか、GatewayのUIのfunctionの画面にて確認することができます。
+
+ ```bash
+$ while [ true ]; do curl -X POST http://localhost:8080/function/nodeinfo; done;
+ ```
+
+### alertの監視
+
+しばらくすると `nodeinfo` functionの呼び出し回数が上昇しているのが上で作ったPrometheusのグラフで確認できます。アラート画面を見ていると、 `APIHighInvocationRate` の状態（色）も `Pending` から `Firing` に変わるのも確認できます。他にも `$ faas-cli list` コマンドやUIからもオートスケールの様子を確認することができます。 ![](../../screenshot/prometheus_firing.png)
+
+`$ docker service ps nodeinfo` の実行結果を見ることでも `nodeinfo` のレプリカが上昇しているのが確認できます。
+
+それではスクリプトを停止してみましょう。数秒もすればレプリカが再び1に戻るのが確認できます。
+
+それでは [Lab 10](lab10.md) に進みましょう。


### PR DESCRIPTION
This is the Japanese version of the OpenFaaS workshop.

The following version(commit) is translated to Japanese.
df8d19b737f399cdfad8985f1ad664b63d2108f9

This workshop has been tested by many users in Japan via a workshop event and is ready to be merged.

The following commits aren't applied yet but will follow  shortly:

* f27ff19c87b0933c51799586d83d5e75cbd78eb2
* 8d91b6407b32fd1c72b0e44406ae12cb67b19b8f

The labs are inside `translations/ja`. Only the labs and not the example codes because it'll be cumbersome to manage both versions.

Signed-off-by: Ken Fukuyama <kenfdev@gmail.com>