### PR TITLE
Add images pre-pull command to lab 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This is a self-paced workshop for learning how to build, deploy and run OpenFaaS
 
 ## Requirements:
 
-We walk through how to install these requirements in [Lab 1](./lab1.md), but please do this before you attend an instructor-led workshop.
+We walk through how to install these requirements in [Lab 1](./lab1.md). Please do [Lab 1](./lab1.md) before you attend an instructor-led workshop.  At the very least you should [install Docker](./lab1.md#docker) and [pre-pull the OpenFaaS images](./lab1.md#Pre-pull-the-system-images).
 
 * Functions will be written in Python, so prior programming or scripting experience is preferred 
 * Install the recommended code-editor / IDE [VSCode](https://code.visualstudio.com/download)
@@ -132,4 +132,4 @@ The [appendix](./appendix.md) contains some additional content.
 
 ## Acknowledgements
 
-Thanks to @iyovcheva, @BurtonR, @johnmccabe, @laurentgrangeau, @stefanprodan, @kenfdev, @templum & rgee0 for testing and contributing to the labs.
+Thanks to @iyovcheva, @BurtonR, @johnmccabe, @laurentgrangeau, @stefanprodan, @kenfdev, @templum & @rgee0 for contributing to, testing and translating the labs.

--- a/lab1.md
+++ b/lab1.md
@@ -33,6 +33,16 @@ Linux - Ubuntu or Debian
 
 Note: As a last resort if you have an incompatible PC you can run the workshop on https://labs.play-with-docker.com/.
 
+### Pre-pull the system images
+
+Pull the most recent OpenFaaS images. 
+
+```
+curl -sSL https://raw.githubusercontent.com/openfaas/faas/master/docker-compose.yml | grep image | awk -F " " '{print $NF}' | xargs -L1 docker pull
+```
+
+This should offset the impact on the workshop WiFi of multiple attendees trying to pull the images at the same time.
+
 ### Setup a single-node cluster
 
 #### Docker Swarm


### PR DESCRIPTION
Experience has shown that multiple attendees trying to download the system images during the workshop can be temperamental where the establishments WiFi is under high load.  This change introduces a pre-pull command to Lab 1 that attendees should run prior to attending.  The pre-reqs preamble in the README has also been changed to further emphasize that the pre-reqs/lab 1 should be addressed prior to attending.

Resolves #56 

Signed-off-by: Richard Gee <richard@technologee.co.uk>