### PR TITLE
Edit Lab3 for astronaut-finder with Kubernetes

### DIFF
--- a/lab3.md
+++ b/lab3.md
@@ -215,19 +215,13 @@ def handle(req):
 
 > Note: in this example we do not make use of the parameter `req` but must keep it in the function's header.
 
-Now build the function:
+Now build, push and deploy the function:
 
 ```
-$ faas-cli build -f ./astronaut-finder.yml
+$ faas-cli up -f ./astronaut-finder.yml
 ```
 
 > Tip: Try renaming astronaut-finder.yml to `stack.yml` and calling just `faas-cli build`. `stack.yml` is the default file-name for the CLI.
-
-Deploy the function:
-
-```
-$ faas-cli deploy -f ./astronaut-finder.yml
-```
 
 Invoke the function
 


### PR DESCRIPTION
When image is prefixed with Docker Registry and not pushed it will
fail on Kubernetes. This is why astronaut-finder example needs
update, as it will never get ready when with Kubernetes version
of the workshop

Signed-off-by: Ivana Yovcheva <iyovcheva@vmware.com>

Closes #101