### PR TITLE
Fixed image tag of "Lab 8"

### DIFF
--- a/lab8.md
+++ b/lab8.md
@@ -57,7 +57,7 @@ functions:
   sleep-for:
     lang: python3
     handler: ./sleep-for
-    image: <your-docker-username-here>/sleep-for:0.1
+    image: <your-docker-username-here>/sleep-for:latest
     environment:
       sleep_duration: 10
       read_timeout: 5

--- a/translations/ja/lab8.md
+++ b/translations/ja/lab8.md
@@ -59,7 +59,7 @@ functions:
   sleep-for:
     lang: python3
     handler: ./sleep-for
-    image: <Docker Hubのユーザー名>/sleep-for:0.1
+    image: <Docker Hubのユーザー名>/sleep-for:latest
     environment:
       sleep_duration: 10
       read_timeout: 5


### PR DESCRIPTION
Hi, Thank you for awesome workshop 👍

# What

I found that image tag of `sleep-for` is wrong.
Because after `faas-cli new`, `latest` is default image tag.

Fixed a little :)

Thanks 🐳🐳🐳