### PR TITLE
Update Tear down/clear link

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ You can start with the first lab [Lab 1](lab1.md).
 
 ## Tear down / Clear up
 
-You can find how to stop and remove OpenFaaS [here](https://github.com/openfaas/faas/blob/master/guide/troubleshooting.md#stop-and-remove-openfaas)
+You can find how to stop and remove OpenFaaS [here](https://docs.openfaas.com/deployment/troubleshooting/#uninstall-openfaas)
 
 ## Wrapping up
 


### PR DESCRIPTION
I was going through the tutorial, trying to clean up my OpenFaas installation, and wasn't sure how to do it. Found this link (https://github.com/openfaas/faas/blob/master/guide/troubleshooting.md#stop-and-remove-openfaas) but it seems that the troubleshooting guide has been moved from github to openfaas.com, and thus the "#stop-and-remove-openfaas" anchor doesn't exist anymore. 

I've updated this link to point directly to docs.openfaas.com and to the appropriate section:
https://docs.openfaas.com/deployment/troubleshooting/#uninstall-openfaas