### PR TITLE
Change Lab9 k8s function to nodeinfo

### DIFF
--- a/lab9.md
+++ b/lab9.md
@@ -169,7 +169,7 @@ $ docker service scale nodeinfo=0
 
 Kubernetes:
 ```
-$ kubectl scale deployment --replicas=0 astronaut-finder -n openfaas-fn
+$ kubectl scale deployment --replicas=0 nodeinfo -n openfaas-fn
 ```
 
 Open the OpenFaaS UI and check that nodeinfo has 0 replicas, or by `docker service ls | grep nodeinfo`.


### PR DESCRIPTION
Swarm and k8s commands were using different functions.  This makes them the same, nodeinfo.

Signed-off-by: Richard Gee <richard@technologee.co.uk>