### PR TITLE
Fix broken link to "Deployment guide"

### DIFF
--- a/lab1a.md
+++ b/lab1a.md
@@ -90,6 +90,6 @@ Watch out for the password and then run the command you are given in the output.
 $ docker service ls
 ```
 
-If you run into any problems, please consult the [Deployment guide](https://github.com/openfaas/faas/blob/master/guide/deployment_swarm.md) for Docker Swarm.
+If you run into any problems, please consult the [Deployment guide](https://docs.openfaas.com/deployment/docker-swarm/) for Docker Swarm.
 
 Now move onto [Lab 2](./lab2.md)


### PR DESCRIPTION
Fix a broken link in the first lab. Since the deployment guide doesn't seem to be available on Github anymore, I refered to [docs.openfaas.com](https://docs.openfaas.com).