### PR TITLE
Add file param to `faas-cli up` command in lab 4

### DIFF
--- a/lab4.md
+++ b/lab4.md
@@ -224,7 +224,7 @@ functions:
         save_path: "/tmp/"
 ```
 
-You can now test the fix by running `faas-cli up` and the files will be written into `/tmp/`.
+You can now test the fix by running `faas-cli up -f ingest-file.yml` one more time and the files will be written into `/tmp/`.
 
 We now have the ability to lock-down our function's code so that it cannot be changed accidentally or updated maliciously. 
 


### PR DESCRIPTION
Trivial change to add file parameter to the faas-cli up command in the narrative. Being explicit should be easier to follow for newer users.

Fixes #135

Signed-off-by: Richard Gee <richard@technologee.co.uk>