### PR TITLE
Add more explicit instructions on when use `gateway.openfaas`

### DIFF
--- a/issue-bot-secrets/bot-handler/handler.py
+++ b/issue-bot-secrets/bot-handler/handler.py
@@ -9,6 +9,7 @@ def handle(req):
         sys.exit(1)
         return
 
+    # Use "gateway.openfaas" in the second argument if using Kubernetes
     gateway_hostname = os.getenv("gateway_hostname", "gateway")
 
     payload = json.loads(req)

--- a/issue-bot-secrets/stack.yml
+++ b/issue-bot-secrets/stack.yml
@@ -10,6 +10,6 @@ functions:
     environment:
       write_debug: true
       positive_threshold: 0.25
-      gateway_hostname: "gateway"
+      gateway_hostname: "gateway"  # use "gateway.openfaas" if using Kubernetes
     secrets:
       - auth-token

--- a/issue-bot/bot-handler/handler.py
+++ b/issue-bot/bot-handler/handler.py
@@ -8,6 +8,7 @@ def handle(req):
         sys.exit("Unable to handle X-GitHub-Event: " + event_header)
         return
 
+    # Use "gateway.openfaas" in the second argument if using Kubernetes
     gateway_hostname = os.getenv("gateway_hostname", "gateway")
 
     payload = json.loads(req)

--- a/issue-bot/stack.yml
+++ b/issue-bot/stack.yml
@@ -11,7 +11,7 @@ functions:
       write_debug: true
       repo: alexellis2/bot-tester
       positive_threshold: 0.25
-      gateway_hostname: "gateway"
+      gateway_hostname: "gateway"  # use "gateway.openfaas" if using Kubernetes
     environment_file:
       - env.yml
     secrets:

--- a/lab4.md
+++ b/lab4.md
@@ -389,7 +389,9 @@ Suffix the gateway host with `openfaas` namespace:
 Or via an environmental variable:
 
 ```python
-    gateway_hostname = os.getenv("gateway_hostname", "gateway") # uses a default of "gateway" for when "gateway_hostname" is not set
+    # uses a default of "gateway" for when "gateway_hostname" is not set
+    # use "gateway.openfaas" if using Kubernetes
+    gateway_hostname = os.getenv("gateway_hostname", "gateway")
     test_sentence = "California is great, it's always sunny there."
     r = requests.get("http://" + gateway_hostname + ":8080/function/sentimentanalysis", data= test_sentence)
 ```
@@ -417,7 +419,9 @@ def handle(req):
         req (str): request body
     """
 
-    gateway_hostname = os.getenv("gateway_hostname", "gateway") # uses a default of "gateway" for when "gateway_hostname" is not set
+    # uses a default of "gateway" for when "gateway_hostname" is not set
+    # use "gateway.openfaas" if using Kubernetes
+    gateway_hostname = os.getenv("gateway_hostname", "gateway")
 
     test_sentence = req
 

--- a/lab5.md
+++ b/lab5.md
@@ -177,6 +177,7 @@ def handle(req):
         sys.exit("Unable to handle X-GitHub-Event: " + event_header)
         return
 
+    # Use "gateway.openfaas" in the second argument if using Kubernetes
     gateway_hostname = os.getenv("gateway_hostname", "gateway")
 
     payload = json.loads(req)
@@ -316,6 +317,7 @@ def handle(req):
         sys.exit("Unable to handle X-GitHub-Event: " + event_header)
         return
 
+     # Use "gateway.openfaas" in the second argument if using Kubernetes
     gateway_hostname = os.getenv("gateway_hostname", "gateway")
 
     payload = json.loads(req)


### PR DESCRIPTION
Hey there 👋 

Just added more explicit instructions through out the workshop on when to use `gateway.openfaas` when setting the `gateway_hostname` variable.

Cheers!