### PR TITLE
Fix requestbin URL in lab7

### DIFF
--- a/lab7.md
+++ b/lab7.md
@@ -101,14 +101,14 @@ Some additional request headers are sent to the callback, for a complete list se
 
 Head over to requestbin and create a new "bin" - this will be a URL on the public internet that can receive your function's result.
 
-https://requestbin.fullcontact.com/
+https://requestbin.com/
 
 Now copy the "Bin URL" and paste it below:
 
-For example (`http://requestbin.fullcontact.com/1i7i1we1`)
+For example (`http://requestbin.com/r/1i7i1we1`)
 
 ```
-$ echo -n "LaterIsBetter" | faas-cli invoke figlet --async --header "X-Callback-Url=http://requestbin.fullcontact.com/1i7i1we1"
+$ echo -n "LaterIsBetter" | faas-cli invoke figlet --async --header "X-Callback-Url=http://requestbin.com/r/1i7i1we1"
 ```
 
 Now refresh the page on the requestbin site and you will see the result from `figlet`:

--- a/translations/ja/lab7.md
+++ b/translations/ja/lab7.md
@@ -92,14 +92,14 @@ OpenFaaSのコールバックの仕組みを使うことで、非同期function�
 
 それではrequestbinを使って新しい「bin」を作ってみましょう。requestbinはインターネット上でリクエストを受け取れるサービスです。
 
-https://requestbin.fullcontact.com/
+https://requestbin.com/
 
 「Bin URL」をコピーして次のように呼び出してみましょう。
 
-例えば `http://requestbin.fullcontact.com/1i7i1we1` の場合
+例えば `http://requestbin.com/r/1i7i1we1` の場合
 
 ```
-$ echo -n "LaterIsBetter" | faas-cli invoke figlet --async --header "X-Callback-Url=http://requestbin.fullcontact.com/1i7i1we1"
+$ echo -n "LaterIsBetter" | faas-cli invoke figlet --async --header "X-Callback-Url=http://requestbin.com/r/1i7i1we1"
 ```
 
 呼び出し後、requestbinのページをリフレッシュしましょう。次のように `figlet` の結果が表示されます：


### PR DESCRIPTION
Hey there 👋 

Request Bin moved to https://requestbin.com, this PR fixes the URLs used in the lab7.