### PR TITLE
Add note to uncheck the private box on requestbin

### DIFF
--- a/lab7.md
+++ b/lab7.md
@@ -101,6 +101,8 @@ Some additional request headers are sent to the callback, for a complete list se
 
 Head over to requestbin and create a new "bin" - this will be a URL on the public internet that can receive your function's result.
 
+> For the purpose of this lab, be sure to uncheck the 'Private' checkbox as this will save you from needing to log in.
+
 https://requestbin.com/
 
 Now copy the "Bin URL" and paste it below:


### PR DESCRIPTION
Signed-off-by: Richard Gee <richard@technologee.co.uk>

## Description
Add note to requestbin.com details that explains the user should uncheck the Private checkbox in order to save them the effort of logging in.

## Motivation and Context
On first trip through I didnt spot it and was prompted to log in.

## How Has This Been Tested?
Trivial text change

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
