### PR TITLE
Update lab1b.md

### DIFF
--- a/lab1b.md
+++ b/lab1b.md
@@ -37,7 +37,7 @@ On MacOS or Linux:
 ```sh
 curl -sSLf https://raw.githubusercontent.com/ahmetb/kubectx/master/kubectx > kubectx
 chmod +x kubectx
-sudo mv kubectx /usr/local/bin/
+mv kubectx /usr/local/bin/
 ```
 
 ## OpenFaaS CLI
@@ -82,7 +82,7 @@ Depending on the option you may also need to install [kubectl](https://kubernete
 
 #### _With Minikube_
 
-* To install Minikube download the proper installer from [latest release](https://github.com/kubernetes/minikube/releases) depending on your platform.
+* [Install Minikube](https://minikube.sigs.k8s.io/docs/start/) This will allow you to run kubernetes locally.
 * [Install Helm client](https://docs.helm.sh/using_helm/#installing-the-helm-client)
 
 * Now run Minikube with


### PR DESCRIPTION
## Description

I'm following the documentation and I've notice that

1. You don't need `sudo` to move `kubectx` (at least no in OSX 10.14.5)
2. Maybe when the document was written, minikube releases on github repository where the way to go but they seem to now have a "Getting Started" page, at the time the page says it was updated on August 12, 2019.

Thank you for instructions, up to this point everything has been working great.
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
