### PR TITLE
Add k3sup instructions

### DIFF
--- a/lab1.md
+++ b/lab1.md
@@ -64,6 +64,32 @@ $ faas-cli help
 $ faas-cli version
 ```
 
+## Configure a registry - The Docker Hub
+
+Sign up for a Docker Hub account. The [Docker Hub](https://hub.docker.com) allows you to publish your Docker images on the Internet for use on multi-node clusters or to share with the wider community. We will be using the Docker Hub to publish our functions during the workshop.
+
+You can sign up here: [Docker Hub](https://hub.docker.com)
+
+Open a Terminal or Git Bash window and log into the Docker Hub using the username you signed up for above.
+
+```
+$ docker login
+```
+
+> Note: Tip from community - if you get an error while trying to run this command on a Windows machine, then click on the Docker for Windows icon in the taskbar and log into Docker there instead "Sign in / Create Docker ID".
+
+* Set your OpenFaaS prefix for new images
+
+OpenFaaS images are stored in a Docker registry or the Docker Hub, we can set an environment variable so that your username is automatically added to new functions you create. This will save you some time over the course of the workshop.
+
+Edit `~/.bashrc` or `~/.bash_profile` - create the file if it doesn't exist.
+
+Now add the following - changing the URL as per the one you saw above.
+
+```
+export OPENFAAS_PREFIX="" # Populate with your Docker Hub username
+```
+
 ### Setup a single-node cluster
 
 If you're taking part in an instructor-lead event then the organiser may ask you to use Docker Swarm, because it's much quicker and easier to set up in a short period of time. For some workshops you will be using Kubernetes.

--- a/lab1.md
+++ b/lab1.md
@@ -72,7 +72,7 @@ You can sign up here: [Docker Hub](https://hub.docker.com)
 
 Open a Terminal or Git Bash window and log into the Docker Hub using the username you signed up for above.
 
-```
+```sh
 $ docker login
 ```
 
@@ -86,7 +86,7 @@ Edit `~/.bashrc` or `~/.bash_profile` - create the file if it doesn't exist.
 
 Now add the following - changing the URL as per the one you saw above.
 
-```
+```sh
 export OPENFAAS_PREFIX="" # Populate with your Docker Hub username
 ```
 
@@ -107,7 +107,7 @@ Start the first lab by picking one of the tracks below:
 
 Pull the most recent OpenFaaS images. 
 
-```
+```sh
 curl -sSL https://raw.githubusercontent.com/openfaas/faas/master/docker-compose.yml | grep image | awk -F " " '{print $NF}' | xargs -L1 docker pull
 ```
 

--- a/lab1a.md
+++ b/lab1a.md
@@ -14,22 +14,6 @@ $ docker swarm init
 
 > If you receive an error then pass the `--advertise-addr` parameter along with your laptop's IP address.
 
-### Docker Hub
-
-Sign up for a Docker Hub account. The [Docker Hub](https://hub.docker.com) allows you to publish your Docker images on the Internet for use on multi-node clusters or to share with the wider community. We will be using the Docker Hub to publish our functions during the workshop.
-
-You can sign up here: [Docker Hub](https://hub.docker.com)
-
-> Note: The Docker Hub can also be setup to automate builds of Docker images.
-
-Open a Terminal or Git Bash window and log into the Docker Hub using the username you signed up for above.
-
-```sh
-$ docker login
-```
-
-> Note: Tip from community - if you get an error while trying to run this command on a Windows machine, then click on the Docker for Windows icon in the taskbar and log into Docker there instead "Sign in / Create Docker ID".
-
 ### Deploy OpenFaaS
 
 The instructions for deploying OpenFaaS change from time to time as we strive to make this easier. The following will get OpenFaaS deployed in around 60 seconds:

--- a/lab1b.md
+++ b/lab1b.md
@@ -236,6 +236,8 @@ If you're using a managed cloud Kubernetes service which supplies LoadBalancers,
 k3sup app install openfaas --loadbalancer
 ```
 
+> Note: the `--loadbalancer` flag has a default of `false`, so by passing the flag, the installation will request one from your cloud provider.
+
 If you're using a local Kubernetes cluster or a VM, then run:
 
 ```sh

--- a/lab1b.md
+++ b/lab1b.md
@@ -204,20 +204,6 @@ NAME                                   STATUS    ROLES     AGE       VERSION
 gke-name-default-pool-eceef152-qjmt   Ready     <none>    1h        v1.10.7-gke.2
 ```
 
-## Configure a registry - The Docker Hub
-
-Sign up for a Docker Hub account. The [Docker Hub](https://hub.docker.com) allows you to publish your Docker images on the Internet for use on multi-node clusters or to share with the wider community. We will be using the Docker Hub to publish our functions during the workshop.
-
-You can sign up here: [Docker Hub](https://hub.docker.com)
-
-Open a Terminal or Git Bash window and log into the Docker Hub using the username you signed up for above.
-
-```
-$ docker login
-```
-
-> Note: Tip from community - if you get an error while trying to run this command on a Windows machine, then click on the Docker for Windows icon in the taskbar and log into Docker there instead "Sign in / Create Docker ID".
-
 ## Deploy OpenFaaS
 
 The instructions for deploying OpenFaaS change from time to time as we strive to make this even easier.
@@ -308,7 +294,7 @@ Edit `~/.bashrc` or `~/.bash_profile` - create the file if it doesn't exist.
 Now add the following - changing the URL as per the one you saw above.
 
 ```
--export OPENFAAS_URL="" # populate as above
+export OPENFAAS_URL="" # populate as above
 ```
 
 Now move onto [Lab 2](lab2.md)

--- a/lab1b.md
+++ b/lab1b.md
@@ -216,16 +216,16 @@ There is a new tool called `k3sup` which can install helm charts, including Open
 
 * Get k3sup
 
-For Windows:
-
-```sh
-curl -SLsf https://get.k3sup.dev/ | sh
-```
-
 For MacOS / Linux:
 
 ```sh
 curl -SLsf https://get.k3sup.dev/ | sudo sh
+```
+
+For Windows:
+
+```sh
+curl -SLsf https://get.k3sup.dev/ | sh
 ```
 
 * Install the OpenFaaS app
@@ -277,7 +277,10 @@ Your URL will be the IP or DNS entry above on port `8080`.
 ```sh
 export OPENFAAS_URL="" # Populate as above
 
+# This command retrieves your password
 PASSWORD=$(kubectl get secret -n openfaas basic-auth -o jsonpath="{.data.basic-auth-password}" | base64 --decode; echo)
+
+# This command logs in and saves a file to ~/.openfaas/config.yml
 echo -n $PASSWORD | faas-cli login --username admin --password-stdin
 ```
 
@@ -293,7 +296,7 @@ Edit `~/.bashrc` or `~/.bash_profile` - create the file if it doesn't exist.
 
 Now add the following - changing the URL as per the one you saw above.
 
-```
+```sh
 export OPENFAAS_URL="" # populate as above
 ```
 

--- a/lab1b.md
+++ b/lab1b.md
@@ -75,7 +75,6 @@ kubectl cluster-info
 #### _With Minikube_
 
 * To install Minikube download the proper installer from [latest release](https://github.com/kubernetes/minikube/releases) depending on your platform.
-* [Install Helm client](https://docs.helm.sh/using_helm/#installing-the-helm-client)
 
 * Now run Minikube with
 
@@ -222,41 +221,6 @@ $ docker login
 ## Deploy OpenFaaS
 
 The instructions for deploying OpenFaaS change from time to time as we strive to make this even easier.
-
-### Install the helm CLI/client
-
-Instructions for latest Helm install
-
-* On Linux and Mac/Darwin:
-
-```sh
-curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get | bash
-```
-
-* Or via Homebrew on Mac:
-
-```sh
-brew install kubernetes-helm
-```
-      
-On Windows [download the helm.exe file](https://helm.sh) and place it in $PATH or /usr/bin/.
-
-### Install tiller
-
-* Create RBAC permissions for tiller
-
-```sh
-kubectl -n kube-system create sa tiller \
-  && kubectl create clusterrolebinding tiller \
-  --clusterrole cluster-admin \
-  --serviceaccount=kube-system:tiller
-```
-
-* Install the server-side Tiller component on your cluster
-
-```sh
-helm init --skip-refresh --upgrade --service-account tiller
-```
 
 ### Install OpenFaaS
 

--- a/lab1b.md
+++ b/lab1b.md
@@ -301,4 +301,14 @@ echo -n $PASSWORD | faas-cli login --username admin --password-stdin
 faas-cli list
 ```
 
+### Permanently save your OpenFaaS URL
+ 
+Edit `~/.bashrc` or `~/.bash_profile` - create the file if it doesn't exist.
+
+Now add the following - changing the URL as per the one you saw above.
+
+```
+-export OPENFAAS_URL="" # populate as above
+```
+
 Now move onto [Lab 2](lab2.md)


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

## Description
<!--- Describe your changes in detail -->

Add [k3sup](https://k3sup.dev/) installation instructions for OpenFaaS

## Motivation and Context

k3sup is a prototype of "faas-cli install" and makes the
experience much easier for newcomers. The longer, manual, and
more detailed instructions are retained in the documentation.

Advanced users are welcome to follow them.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

`k3sup` has been tested by the community and in several blog posts on https://blog.alexellis.io/
