### PR TITLE
Fix typo in install command for openfaas on managed cloud Kubernetes

### DIFF
--- a/lab1b.md
+++ b/lab1b.md
@@ -233,7 +233,7 @@ curl -SLsf https://get.k3sup.dev/ | sh
 If you're using a managed cloud Kubernetes service which supplies LoadBalancers, then run the following:
 
 ```sh
-k3sup app install openfaas --loadbalancer
+k3sup app install openfaas --load-balancer
 ```
 
 > Note: the `--loadbalancer` flag has a default of `false`, so by passing the flag, the installation will request one from your cloud provider.


### PR DESCRIPTION
Fix installation instructions for installation on managed cloud.

## Description
Fix a typo in the documentation. 

## Motivation and Context
Without this fix, installation with a load balancer fails with this error: 
```
Error: unknown flag: --loadbalancer
```

## How Has This Been Tested?
Command has been executed successfully with the changed notation. 

## Types of changes
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
This is only a one-line documentation change. 

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
