### PR TITLE
Update the swarm lab 1a for more info on login command

### DIFF
--- a/lab1a.md
+++ b/lab1a.md
@@ -39,9 +39,20 @@ $ cd faas && \
 $ ./deploy_stack.sh
 ```
 
-Watch out for the password and then run the command you are given in the output.
+Your gateway URL is: `http://127.0.0.1:8080`
 
-* Run the `faas-cli login` command
+Watch out for the password and then run the commands below, or the login command printed to the console.
+
+```shell script
+# This exports your password to and environment variable for use in the following commands
+export PASSWORD=<password-printed-in-console>
+
+# This command sets the URL for the gateway, used by the faas-cli command
+export OPENFAAS_URL=http://127.0.0.1:8080
+
+# This command logs in and saves a file to ~/.openfaas/config.yml
+echo -n $PASSWORD | faas-cli login --username admin --password-stdin
+```
 
 * Check if the services are up and showing 1/1 for each:
 


### PR DESCRIPTION
# Description
The faas-cli login section on swarm was just saying
"use the printed command" rather than outlining what
each section does like the k8s lab shows.

closes #141 
Signed-off-by: Alistair Hey <alistair@heyal.co.uk>

<!--- Provide a general summary of your changes in the Title above -->

<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
#141 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
Docs update
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
