### PR TITLE
Update the link target to reference 'Callback request headers' section

### DIFF
--- a/lab7.md
+++ b/lab7.md
@@ -97,7 +97,7 @@ This option may not be suitable in all circumstances and involves writing additi
 * Make use of the built-in behaviour of callbacks
 
 The built-in callbacks allow a call to a function to provide a URL where the queue-worker will automatically report the success or failure of a function along with the result.
-Some additional request headers are sent to the callback, for a complete list see [Callback request headers](https://github.com/openfaas/docs/blob/master/docs/reference/async.md#callback-request-headers)
+Some additional request headers are sent to the callback, for a complete list see [Callback request headers](https://docs.openfaas.com/reference/async/#callback-request-headers)
 
 Head over to requestbin and create a new "bin" - this will be a URL on the public internet that can receive your function's result.
 

--- a/lab7.md
+++ b/lab7.md
@@ -97,7 +97,7 @@ This option may not be suitable in all circumstances and involves writing additi
 * Make use of the built-in behaviour of callbacks
 
 The built-in callbacks allow a call to a function to provide a URL where the queue-worker will automatically report the success or failure of a function along with the result.
-Some additional request headers are sent to the callback, for a complete list see [https://github.com/openfaas/docs/blob/master/docs/deployment/troubleshooting.md#callback-request-headers]
+Some additional request headers are sent to the callback, for a complete list see [Callback request headers](https://github.com/openfaas/docs/blob/master/docs/reference/async.md#callback-request-headers)
 
 Head over to requestbin and create a new "bin" - this will be a URL on the public internet that can receive your function's result.
 


### PR DESCRIPTION
Signed-off-by: Andreas Amstutz <andreasamstutz@gmail.com>

## Description
The current link target does not lead to reference for callback request headers.

## Motivation and Context
- [x] I have raised an issue to propose this change ([Lab 7: Wrong link target to 'Callback request headers'](https://github.com/openfaas/workshop/issues/169))

## How Has This Been Tested?
I followed the updated link to the reference.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
