### PR TITLE
Waterdrips fix lab2

### DIFF
--- a/lab1a.md
+++ b/lab1a.md
@@ -39,9 +39,20 @@ $ cd faas && \
 $ ./deploy_stack.sh
 ```
 
-Watch out for the password and then run the command you are given in the output.
+Your gateway URL is: `http://127.0.0.1:8080`
 
-* Run the `faas-cli login` command
+Watch out for the password and then run the commands below, or the login command printed to the console.
+
+```shell script
+# This exports your password to and environment variable for use in the following commands
+export PASSWORD=<password-printed-in-console>
+
+# This command sets the URL for the gateway, used by the faas-cli command
+export OPENFAAS_URL=http://127.0.0.1:8080
+
+# This command logs in and saves a file to ~/.openfaas/config.yml
+echo -n $PASSWORD | faas-cli login --username admin --password-stdin
+```
 
 * Check if the services are up and showing 1/1 for each:
 

--- a/lab2.md
+++ b/lab2.md
@@ -165,7 +165,7 @@ grafana
 Expose Grafana with a NodePort:
 
 ```sh
-kubectl -n openfaas expose deployment grafana \
+kubectl -n openfaas expose pod grafana \
 --type=NodePort \
 --name=grafana
 ```


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
kubectl 1.18 changed run to create only a pod, not a pod wrapped in a deployment


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
