### PR TITLE
Update lab5.md

### DIFF
--- a/lab5.md
+++ b/lab5.md
@@ -44,11 +44,11 @@ $ kubectl -n openfaas run \
 --port=4040 \
 ngrok -- http gateway:8080
 
-$ kubectl -n openfaas expose deployment ngrok \
+$ kubectl -n openfaas expose pod ngrok \
 --type=NodePort \
 --name=ngrok
 
-$ kubectl port-forward deployment/ngrok 4040:4040 -n openfaas
+$ kubectl port-forward pod/ngrok 4040:4040 -n openfaas
 ```
 
 Use the built-in UI of `ngrok` at http://127.0.0.1:4040 to find your HTTP URL. You will be given a URL that you can access over the Internet, it will connect directly to your OpenFaaS API Gateway.


### PR DESCRIPTION
because the prefix ``kubectl -n openfaas run`` command doesn't create the deployment, so change expose and port-forward to pod

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
