### PR TITLE
Update the merge command flags

### DIFF
--- a/lab1b.md
+++ b/lab1b.md
@@ -49,7 +49,7 @@ If you have Docker on your computer, then you can use `k3d` from Rancher Labs. I
 * Start a cluster
 
 1. `k3d cluster create CLUSTER_NAME` to create a new single-node cluster (= 1 container running k3s + 1 loadbalancer container)
-2. `k3d kubeconfig merge CLUSTER_NAME --switch-context` to update your default kubeconfig and switch the current-context to the new one
+2. `k3d kubeconfig merge CLUSTER_NAME --kubeconfig-switch-context` or `k3d kubeconfig merge CLUSTER_NAME -s` to update your default kubeconfig and switch the current-context to the new one
 3. execute some commands like `kubectl get pods --all-namespaces`
 If you want to delete default cluster `k3d cluster delete CLUSTER_NAME`
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
From the current k3d documentation, the merge command flag  'switch-context' is no longer available. 
The current options for 'Switch to new context (default true)' are -s ou --switch-context.

## Description
<!--- Describe your changes in detail -->

From the current k3d documentation, the merge command flag  'switch-context' is no longer available. 
Then, "k3d kubeconfig merge CLUSTER_NAME --switch-context" causes the error: "unknown flag: --switch-context"

The current options for 'Switch to new context (default true)' are -s ou --switch-context.
Then, I suggest to add both.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I have worked on the Labs.
<!--- Include details of your testing environment, and the tests you ran to -->
I ran in my own machine.
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
