### PR TITLE
Fixed arkade install url

### DIFF
--- a/lab1b.md
+++ b/lab1b.md
@@ -213,7 +213,7 @@ For MacOS / Linux:
 
 ```sh
 # MacOS users may need to run "bash" first if this command fails
-curl -SLsf https://get-arkade.dev/ | sudo sh
+curl -sLS https://get.arkade.dev | sudo sh
 ```
 
 For Windows:


### PR DESCRIPTION
Fixed arkade install url

Fixed arkade install url, the url in the workshop fails

## Description
When trying to install arkade using the url in the workshop fails

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
arkade was successfully installed after using the new installation url

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
